### PR TITLE
feat(execution): add message polling and benchmark run orchestration

### DIFF
--- a/src/main/java/dk/viplev/agent/AgentApplication.java
+++ b/src/main/java/dk/viplev/agent/AgentApplication.java
@@ -2,8 +2,10 @@ package dk.viplev.agent;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class AgentApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/dk/viplev/agent/adapter/inbound/scheduling/MessagePollingAdapter.java
+++ b/src/main/java/dk/viplev/agent/adapter/inbound/scheduling/MessagePollingAdapter.java
@@ -1,0 +1,116 @@
+package dk.viplev.agent.adapter.inbound.scheduling;
+
+import dk.viplev.agent.domain.model.RunContext;
+import dk.viplev.agent.generated.model.BenchmarkDTO;
+import dk.viplev.agent.generated.model.MessageDTO;
+import dk.viplev.agent.port.inbound.BenchmarkExecutionUseCase;
+import dk.viplev.agent.port.outbound.rest.ViplevApiPort;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Profile;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.UUID;
+
+@Component
+@Profile("docker")
+public class MessagePollingAdapter {
+
+    private static final Logger log = LoggerFactory.getLogger(MessagePollingAdapter.class);
+
+    private final ViplevApiPort viplevApiPort;
+    private final BenchmarkExecutionUseCase benchmarkExecutionUseCase;
+    private final RunContext runContext;
+    private final long idlePollIntervalMs;
+    private final long activePollIntervalMs;
+
+    private volatile long lastPollAtMs;
+
+    public MessagePollingAdapter(ViplevApiPort viplevApiPort,
+                                 BenchmarkExecutionUseCase benchmarkExecutionUseCase,
+                                 RunContext runContext,
+                                 @Value("${agent.message-polling-idle-interval-ms:15000}") long idlePollIntervalMs,
+                                 @Value("${agent.message-polling-active-interval-ms:5000}") long activePollIntervalMs) {
+        this.viplevApiPort = viplevApiPort;
+        this.benchmarkExecutionUseCase = benchmarkExecutionUseCase;
+        this.runContext = runContext;
+        this.idlePollIntervalMs = idlePollIntervalMs;
+        this.activePollIntervalMs = activePollIntervalMs;
+    }
+
+    @Scheduled(fixedDelayString = "${agent.message-polling-tick-ms:1000}")
+    public void pollMessagesSafely() {
+        pollMessagesSafely(System.currentTimeMillis());
+    }
+
+    void pollMessagesSafely(long nowMs) {
+        if (!shouldPollNow(nowMs)) {
+            return;
+        }
+
+        lastPollAtMs = nowMs;
+        try {
+            List<MessageDTO> messages = viplevApiPort.pollMessages();
+            handleMessages(messages);
+        } catch (Exception e) {
+            log.warn("Failed to poll messages from VIPLEV; will retry on next poll", e);
+        }
+    }
+
+    boolean shouldPollNow(long nowMs) {
+        if (lastPollAtMs == 0) {
+            return true;
+        }
+        long intervalMs = runContext.isActive() ? activePollIntervalMs : idlePollIntervalMs;
+        return nowMs - lastPollAtMs >= intervalMs;
+    }
+
+    private void handleMessages(List<MessageDTO> messages) {
+        if (messages == null || messages.isEmpty()) {
+            return;
+        }
+
+        if (messages.size() > 1) {
+            log.warn("Received {} pending messages; processing only the first one", messages.size());
+        }
+
+        MessageDTO message = messages.getFirst();
+        if (message == null) {
+            log.warn("Received null message; ignoring");
+            return;
+        }
+        handleMessage(message);
+    }
+
+    private void handleMessage(MessageDTO message) {
+        if (message.getMessageType() == null) {
+            log.warn("Received message with null type; ignoring");
+            return;
+        }
+
+        UUID benchmarkId = message.getBenchmarkId();
+        UUID runId = message.getRunId();
+        if (benchmarkId == null || runId == null) {
+            log.warn("Received message of type {} with null benchmarkId or runId; ignoring",
+                    message.getMessageType());
+            return;
+        }
+
+        switch (message.getMessageType()) {
+            case PENDING_START -> {
+                log.info("Received PENDING_START for benchmark={} run={}", benchmarkId, runId);
+                BenchmarkDTO benchmark = viplevApiPort.getBenchmark(benchmarkId);
+                String k6Instructions = benchmark != null ? benchmark.getK6Instructions() : null;
+                benchmarkExecutionUseCase.startRun(benchmarkId, runId, k6Instructions);
+            }
+            case PENDING_STOP -> {
+                log.info("Received PENDING_STOP for benchmark={} run={}", benchmarkId, runId);
+                benchmarkExecutionUseCase.stopRun(benchmarkId, runId);
+            }
+            default -> log.warn("Unknown message type: {}", message.getMessageType());
+        }
+    }
+}

--- a/src/main/java/dk/viplev/agent/adapter/inbound/scheduling/MessagePollingAdapter.java
+++ b/src/main/java/dk/viplev/agent/adapter/inbound/scheduling/MessagePollingAdapter.java
@@ -51,9 +51,9 @@ public class MessagePollingAdapter {
             return;
         }
 
-        lastPollAtMs = nowMs;
         try {
             List<MessageDTO> messages = viplevApiPort.pollMessages();
+            lastPollAtMs = nowMs;
             handleMessages(messages);
         } catch (Exception e) {
             log.warn("Failed to poll messages from VIPLEV; will retry on next poll", e);

--- a/src/main/java/dk/viplev/agent/adapter/inbound/scheduling/MetricCollectorAdapter.java
+++ b/src/main/java/dk/viplev/agent/adapter/inbound/scheduling/MetricCollectorAdapter.java
@@ -1,54 +1,19 @@
 package dk.viplev.agent.adapter.inbound.scheduling;
 
-import dk.viplev.agent.generated.model.BenchmarkRunStatusUpdateDTO;
-import dk.viplev.agent.generated.model.MessageDTO;
 import dk.viplev.agent.port.inbound.MetricCollectionUseCase;
-import dk.viplev.agent.port.outbound.rest.ViplevApiPort;
-import jakarta.annotation.PreDestroy;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.context.annotation.Profile;
-import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
 
-import java.util.List;
 import java.util.UUID;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
 
 @Component
 @Profile("docker")
 public class MetricCollectorAdapter {
 
-    private static final Logger log = LoggerFactory.getLogger(MetricCollectorAdapter.class);
-    private static final long POLL_INTERVAL_MS = 5000;
-
     private final MetricCollectionUseCase metricCollectionUseCase;
-    private final ViplevApiPort viplevApiPort;
-    private final ScheduledExecutorService poller;
 
-    public MetricCollectorAdapter(MetricCollectionUseCase metricCollectionUseCase,
-                                  ViplevApiPort viplevApiPort) {
+    public MetricCollectorAdapter(MetricCollectionUseCase metricCollectionUseCase) {
         this.metricCollectionUseCase = metricCollectionUseCase;
-        this.viplevApiPort = viplevApiPort;
-        this.poller = Executors.newSingleThreadScheduledExecutor(r -> {
-            Thread t = new Thread(r, "message-poller");
-            t.setDaemon(true);
-            return t;
-        });
-    }
-
-    @EventListener(ApplicationReadyEvent.class)
-    public void onApplicationReady() {
-        log.info("Starting message polling loop (interval={}ms)", POLL_INTERVAL_MS);
-        poller.scheduleAtFixedRate(this::pollMessagesSafely, 0, POLL_INTERVAL_MS, TimeUnit.MILLISECONDS);
-    }
-
-    @PreDestroy
-    void shutdown() {
-        poller.shutdownNow();
     }
 
     public boolean startCollection(UUID benchmarkId, UUID runId) {
@@ -57,58 +22,5 @@ public class MetricCollectorAdapter {
 
     public boolean stopCollection() {
         return metricCollectionUseCase.stopCollection();
-    }
-
-    void pollMessagesSafely() {
-        try {
-            List<MessageDTO> messages = viplevApiPort.pollMessages();
-            for (MessageDTO message : messages) {
-                handleMessage(message);
-            }
-        } catch (Exception e) {
-            log.warn("Failed to poll messages from VIPLEV; will retry on next poll", e);
-        }
-    }
-
-    private void handleMessage(MessageDTO message) {
-        if (message.getMessageType() == null) {
-            log.warn("Received message with null type; ignoring");
-            return;
-        }
-
-        UUID benchmarkId = message.getBenchmarkId();
-        UUID runId = message.getRunId();
-
-        if (benchmarkId == null || runId == null) {
-            log.warn("Received message of type {} with null benchmarkId or runId; ignoring",
-                    message.getMessageType());
-            return;
-        }
-
-        switch (message.getMessageType()) {
-            case PENDING_START -> {
-                log.info("Received PENDING_START for benchmark={} run={}", benchmarkId, runId);
-                boolean started = metricCollectionUseCase.startCollection(benchmarkId, runId);
-                if (started) {
-                    viplevApiPort.updateRunStatus(benchmarkId, runId,
-                            new BenchmarkRunStatusUpdateDTO().status(BenchmarkRunStatusUpdateDTO.StatusEnum.STARTED));
-                } else {
-                    log.warn("Ignoring PENDING_START status update because collection state did not transition for benchmark={} run={}",
-                            benchmarkId, runId);
-                }
-            }
-            case PENDING_STOP -> {
-                log.info("Received PENDING_STOP for benchmark={} run={}", benchmarkId, runId);
-                boolean stopped = metricCollectionUseCase.stopCollection();
-                if (stopped) {
-                    viplevApiPort.updateRunStatus(benchmarkId, runId,
-                            new BenchmarkRunStatusUpdateDTO().status(BenchmarkRunStatusUpdateDTO.StatusEnum.STOPPED));
-                } else {
-                    log.warn("Ignoring PENDING_STOP status update because collection state did not transition for benchmark={} run={}",
-                            benchmarkId, runId);
-                }
-            }
-            default -> log.warn("Unknown message type: {}", message.getMessageType());
-        }
     }
 }

--- a/src/main/java/dk/viplev/agent/adapter/outbound/container/docker/DockerContainerAdapter.java
+++ b/src/main/java/dk/viplev/agent/adapter/outbound/container/docker/DockerContainerAdapter.java
@@ -114,6 +114,25 @@ public class DockerContainerAdapter implements ContainerPort, Closeable {
     }
 
     @Override
+    public boolean isContainerRunning(String containerId) {
+        return execute("check if container is running " + containerId, () -> {
+            InspectContainerResponse inspect = dockerClient.inspectContainerCmd(containerId).exec();
+            return inspect.getState() != null && Boolean.TRUE.equals(inspect.getState().getRunning());
+        });
+    }
+
+    @Override
+    public Long getContainerExitCode(String containerId) {
+        return execute("get container exit code " + containerId, () -> {
+            InspectContainerResponse inspect = dockerClient.inspectContainerCmd(containerId).exec();
+            if (inspect.getState() == null) {
+                return null;
+            }
+            return inspect.getState().getExitCodeLong();
+        });
+    }
+
+    @Override
     public void watchContainerEvents(Consumer<ContainerEvent> callback) {
         execute("watch container events", () -> {
             if (eventStream != null) {

--- a/src/main/java/dk/viplev/agent/adapter/outbound/rest/ViplevApiAdapter.java
+++ b/src/main/java/dk/viplev/agent/adapter/outbound/rest/ViplevApiAdapter.java
@@ -2,14 +2,16 @@ package dk.viplev.agent.adapter.outbound.rest;
 
 import dk.viplev.agent.domain.exception.ViplevApiException;
 import dk.viplev.agent.generated.api.AgentApi;
+import dk.viplev.agent.generated.api.BenchmarkApi;
 import dk.viplev.agent.generated.model.BenchmarkRunStatusUpdateDTO;
+import dk.viplev.agent.generated.model.BenchmarkDTO;
 import dk.viplev.agent.generated.model.MessageDTO;
 import dk.viplev.agent.generated.model.MetricPerformanceDTO;
 import dk.viplev.agent.generated.model.MetricResourceDTO;
 import dk.viplev.agent.generated.model.ServiceRegistrationDTO;
 import dk.viplev.agent.port.outbound.rest.ViplevApiPort;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestClientResponseException;
@@ -18,18 +20,31 @@ import java.util.List;
 import java.util.UUID;
 import java.util.function.Supplier;
 
-@Slf4j
 @Component
-@RequiredArgsConstructor
 public class ViplevApiAdapter implements ViplevApiPort {
 
+    private static final Logger log = LoggerFactory.getLogger(ViplevApiAdapter.class);
+
     private final AgentApi agentApi;
+    private final BenchmarkApi benchmarkApi;
     private final UUID viplevEnvironmentId;
+
+    public ViplevApiAdapter(AgentApi agentApi, BenchmarkApi benchmarkApi, UUID viplevEnvironmentId) {
+        this.agentApi = agentApi;
+        this.benchmarkApi = benchmarkApi;
+        this.viplevEnvironmentId = viplevEnvironmentId;
+    }
 
     @Override
     public List<MessageDTO> pollMessages() {
         log.debug("Polling messages for environment {}", viplevEnvironmentId);
         return execute("poll messages", () -> agentApi.listMessages(viplevEnvironmentId));
+    }
+
+    @Override
+    public BenchmarkDTO getBenchmark(UUID benchmarkId) {
+        log.debug("Fetching benchmark {} for environment {}", benchmarkId, viplevEnvironmentId);
+        return execute("fetch benchmark", () -> benchmarkApi.getBenchmark(benchmarkId, viplevEnvironmentId));
     }
 
     @Override

--- a/src/main/java/dk/viplev/agent/config/ViplevApiConfig.java
+++ b/src/main/java/dk/viplev/agent/config/ViplevApiConfig.java
@@ -1,6 +1,7 @@
 package dk.viplev.agent.config;
 
 import dk.viplev.agent.generated.api.AgentApi;
+import dk.viplev.agent.generated.api.BenchmarkApi;
 import dk.viplev.agent.generated.invoker.ApiClient;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
@@ -33,6 +34,11 @@ public class ViplevApiConfig {
     @Bean
     public AgentApi agentApi(ApiClient apiClient) {
         return new AgentApi(apiClient);
+    }
+
+    @Bean
+    public BenchmarkApi benchmarkApi(ApiClient apiClient) {
+        return new BenchmarkApi(apiClient);
     }
 
     @Bean

--- a/src/main/java/dk/viplev/agent/domain/model/RunContext.java
+++ b/src/main/java/dk/viplev/agent/domain/model/RunContext.java
@@ -1,0 +1,65 @@
+package dk.viplev.agent.domain.model;
+
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicReference;
+
+@Component
+public class RunContext {
+
+    private final AtomicReference<CurrentRun> currentRun = new AtomicReference<>();
+
+    public Optional<CurrentRun> getCurrentRun() {
+        return Optional.ofNullable(currentRun.get());
+    }
+
+    public boolean isActive() {
+        return currentRun.get() != null;
+    }
+
+    public boolean activate(UUID benchmarkId, UUID runId) {
+        return currentRun.compareAndSet(null, new CurrentRun(benchmarkId, runId, null));
+    }
+
+    public boolean isActive(UUID benchmarkId, UUID runId) {
+        CurrentRun run = currentRun.get();
+        return run != null && run.benchmarkId().equals(benchmarkId) && run.runId().equals(runId);
+    }
+
+    public Optional<CurrentRun> setK6ContainerId(String containerId) {
+        while (true) {
+            CurrentRun run = currentRun.get();
+            if (run == null) {
+                return Optional.empty();
+            }
+            CurrentRun updated = new CurrentRun(run.benchmarkId(), run.runId(), containerId);
+            if (currentRun.compareAndSet(run, updated)) {
+                return Optional.of(updated);
+            }
+        }
+    }
+
+    public Optional<CurrentRun> deactivateIfMatch(UUID benchmarkId, UUID runId) {
+        while (true) {
+            CurrentRun run = currentRun.get();
+            if (run == null) {
+                return Optional.empty();
+            }
+            if (!run.benchmarkId().equals(benchmarkId) || !run.runId().equals(runId)) {
+                return Optional.empty();
+            }
+            if (currentRun.compareAndSet(run, null)) {
+                return Optional.of(run);
+            }
+        }
+    }
+
+    public Optional<CurrentRun> deactivate() {
+        return Optional.ofNullable(currentRun.getAndSet(null));
+    }
+
+    public record CurrentRun(UUID benchmarkId, UUID runId, String k6ContainerId) {
+    }
+}

--- a/src/main/java/dk/viplev/agent/domain/services/BenchmarkExecutionServiceImpl.java
+++ b/src/main/java/dk/viplev/agent/domain/services/BenchmarkExecutionServiceImpl.java
@@ -1,0 +1,251 @@
+package dk.viplev.agent.domain.services;
+
+import dk.viplev.agent.adapter.inbound.scheduling.MetricCollectorAdapter;
+import dk.viplev.agent.domain.exception.AgentException;
+import dk.viplev.agent.domain.model.ContainerStartRequest;
+import dk.viplev.agent.domain.model.RunContext;
+import dk.viplev.agent.generated.model.BenchmarkRunStatusUpdateDTO;
+import dk.viplev.agent.generated.model.MetricPerformanceDTO;
+import dk.viplev.agent.port.inbound.BenchmarkExecutionUseCase;
+import dk.viplev.agent.port.outbound.container.ContainerPort;
+import dk.viplev.agent.port.outbound.rest.ViplevApiPort;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Service;
+
+import jakarta.annotation.PreDestroy;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.atomic.AtomicInteger;
+
+@Service
+@Profile("docker")
+public class BenchmarkExecutionServiceImpl implements BenchmarkExecutionUseCase {
+
+    private static final Logger log = LoggerFactory.getLogger(BenchmarkExecutionServiceImpl.class);
+    private static final AtomicInteger RUNNER_THREAD_COUNTER = new AtomicInteger(0);
+
+    private final RunContext runContext;
+    private final ViplevApiPort viplevApiPort;
+    private final MetricCollectorAdapter metricCollectorAdapter;
+    private final ContainerPort containerPort;
+    private final String k6Image;
+    private final String k6Network;
+    private final long completionPollIntervalMs;
+    private final ExecutorService runExecutor;
+
+    public BenchmarkExecutionServiceImpl(RunContext runContext,
+                                         ViplevApiPort viplevApiPort,
+                                         MetricCollectorAdapter metricCollectorAdapter,
+                                         ContainerPort containerPort,
+                                         @Value("${agent.k6-image}") String k6Image,
+                                         @Value("${agent.k6-network}") String k6Network,
+                                         @Value("${agent.k6-completion-poll-interval-ms:1000}") long completionPollIntervalMs) {
+        this(runContext, viplevApiPort, metricCollectorAdapter, containerPort,
+                k6Image, k6Network, completionPollIntervalMs,
+                Executors.newSingleThreadExecutor(daemonThreadFactory()));
+    }
+
+    BenchmarkExecutionServiceImpl(RunContext runContext,
+                                  ViplevApiPort viplevApiPort,
+                                  MetricCollectorAdapter metricCollectorAdapter,
+                                  ContainerPort containerPort,
+                                  String k6Image,
+                                  String k6Network,
+                                  long completionPollIntervalMs,
+                                  ExecutorService runExecutor) {
+        this.runContext = runContext;
+        this.viplevApiPort = viplevApiPort;
+        this.metricCollectorAdapter = metricCollectorAdapter;
+        this.containerPort = containerPort;
+        this.k6Image = k6Image;
+        this.k6Network = k6Network;
+        this.completionPollIntervalMs = completionPollIntervalMs;
+        this.runExecutor = runExecutor;
+    }
+
+    @Override
+    public void startRun(UUID benchmarkId, UUID runId, String k6Instructions) {
+        if (benchmarkId == null || runId == null) {
+            throw new AgentException("benchmarkId and runId are required for startRun");
+        }
+
+        if (!runContext.activate(benchmarkId, runId)) {
+            var activeRun = runContext.getCurrentRun();
+            log.warn("Ignoring PENDING_START for benchmark={} run={} because active run is {}",
+                    benchmarkId, runId, activeRun.orElse(null));
+            return;
+        }
+
+        runExecutor.submit(() -> executeRun(benchmarkId, runId, k6Instructions));
+    }
+
+    private void executeRun(UUID benchmarkId, UUID runId, String k6Instructions) {
+
+        String k6ContainerId = null;
+        boolean metricsStarted = false;
+        try {
+            if (k6Instructions == null || k6Instructions.isBlank()) {
+                throw new AgentException("k6Instructions are required for startRun");
+            }
+
+            viplevApiPort.updateRunStatus(benchmarkId, runId, statusUpdate(BenchmarkRunStatusUpdateDTO.StatusEnum.STARTED, null));
+
+            metricsStarted = metricCollectorAdapter.startCollection(benchmarkId, runId);
+            if (!metricsStarted) {
+                throw new AgentException("Failed to start metric collection");
+            }
+
+            k6ContainerId = containerPort.startContainer(k6StartRequest(k6Instructions));
+            if (runContext.setK6ContainerId(k6ContainerId).isEmpty()) {
+                containerPort.stopContainer(k6ContainerId);
+                return;
+            }
+
+            boolean completedNaturally = waitForContainerToComplete(benchmarkId, runId, k6ContainerId);
+            if (!completedNaturally) {
+                return;
+            }
+
+            if (!runContext.isActive(benchmarkId, runId)) {
+                return;
+            }
+
+            stopMetricsSilently();
+            sendEmptyPerformanceMetrics(benchmarkId, runId);
+            viplevApiPort.updateRunStatus(benchmarkId, runId, statusUpdate(BenchmarkRunStatusUpdateDTO.StatusEnum.FINISHED, null));
+        } catch (Exception e) {
+            failRun(benchmarkId, runId, k6ContainerId, metricsStarted, e);
+        } finally {
+            runContext.deactivateIfMatch(benchmarkId, runId);
+        }
+    }
+
+    @PreDestroy
+    void shutdown() {
+        runExecutor.shutdownNow();
+    }
+
+    @Override
+    public void stopRun(UUID benchmarkId, UUID runId) {
+        var runToStop = runContext.deactivateIfMatch(benchmarkId, runId);
+        if (runToStop.isEmpty()) {
+            var currentRun = runContext.getCurrentRun();
+            if (currentRun.isPresent()) {
+                var run = currentRun.get();
+                log.warn("Ignoring PENDING_STOP for benchmark={} run={} because active run is benchmark={} run={}",
+                        benchmarkId, runId, run.benchmarkId(), run.runId());
+            } else {
+                log.warn("Ignoring PENDING_STOP for benchmark={} run={} because no run is active", benchmarkId, runId);
+            }
+            return;
+        }
+
+        var run = runToStop.get();
+
+        try {
+            if (run.k6ContainerId() != null) {
+                containerPort.stopContainer(run.k6ContainerId());
+            }
+        } finally {
+            stopMetricsSilently();
+            viplevApiPort.updateRunStatus(benchmarkId, runId, statusUpdate(BenchmarkRunStatusUpdateDTO.StatusEnum.STOPPED, null));
+        }
+    }
+
+    private ContainerStartRequest k6StartRequest(String k6Instructions) {
+        return new ContainerStartRequest(
+                k6Image,
+                Map.of("K6_SCRIPT", k6Instructions),
+                Map.of(),
+                k6Network,
+                List.of("run", "-"));
+    }
+
+    private boolean waitForContainerToComplete(UUID benchmarkId, UUID runId, String containerId) {
+        while (true) {
+            if (!runContext.isActive(benchmarkId, runId)) {
+                return false;
+            }
+
+            boolean isRunning = containerPort.isContainerRunning(containerId);
+            if (isRunning) {
+                sleep(completionPollIntervalMs);
+                continue;
+            }
+
+            Long exitCode = containerPort.getContainerExitCode(containerId);
+            if (exitCode != null && exitCode != 0L) {
+                throw new AgentException("K6 container exited with code " + exitCode);
+            }
+            return true;
+        }
+    }
+
+    private void failRun(UUID benchmarkId,
+                         UUID runId,
+                         String k6ContainerId,
+                         boolean metricsStarted,
+                         Exception exception) {
+        try {
+            if (k6ContainerId != null) {
+                containerPort.stopContainer(k6ContainerId);
+            }
+        } catch (Exception stopException) {
+            log.warn("Failed to stop k6 container during failure handling", stopException);
+        }
+
+        if (metricsStarted) {
+            stopMetricsSilently();
+        }
+
+        if (!runContext.isActive(benchmarkId, runId)) {
+            return;
+        }
+
+        String reason = exception.getMessage() == null ? "Unknown run failure" : exception.getMessage();
+        viplevApiPort.updateRunStatus(benchmarkId, runId,
+                statusUpdate(BenchmarkRunStatusUpdateDTO.StatusEnum.FAILED, reason));
+    }
+
+    private void stopMetricsSilently() {
+        try {
+            metricCollectorAdapter.stopCollection();
+        } catch (Exception e) {
+            log.warn("Failed to stop metric collection cleanly", e);
+        }
+    }
+
+    private void sendEmptyPerformanceMetrics(UUID benchmarkId, UUID runId) {
+        viplevApiPort.sendPerformanceMetrics(benchmarkId, runId,
+                new MetricPerformanceDTO().httpMetrics(List.of()).vusMetrics(List.of()));
+    }
+
+    private BenchmarkRunStatusUpdateDTO statusUpdate(BenchmarkRunStatusUpdateDTO.StatusEnum status, String reason) {
+        return new BenchmarkRunStatusUpdateDTO().status(status).statusReason(reason);
+    }
+
+    private void sleep(long millis) {
+        try {
+            Thread.sleep(millis);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new AgentException("Interrupted while waiting for k6 container completion", e);
+        }
+    }
+
+    private static ThreadFactory daemonThreadFactory() {
+        return runnable -> {
+            Thread thread = new Thread(runnable,
+                    "benchmark-execution-" + RUNNER_THREAD_COUNTER.getAndIncrement());
+            thread.setDaemon(true);
+            return thread;
+        };
+    }
+}

--- a/src/main/java/dk/viplev/agent/domain/services/BenchmarkExecutionServiceImpl.java
+++ b/src/main/java/dk/viplev/agent/domain/services/BenchmarkExecutionServiceImpl.java
@@ -16,6 +16,9 @@ import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Service;
 
 import jakarta.annotation.PreDestroy;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -31,6 +34,7 @@ public class BenchmarkExecutionServiceImpl implements BenchmarkExecutionUseCase 
 
     private static final Logger log = LoggerFactory.getLogger(BenchmarkExecutionServiceImpl.class);
     private static final AtomicInteger RUNNER_THREAD_COUNTER = new AtomicInteger(0);
+    private static final String K6_SCRIPT_CONTAINER_PATH = "/tmp/viplev-k6-script.js";
 
     private final RunContext runContext;
     private final ViplevApiPort viplevApiPort;
@@ -99,6 +103,7 @@ public class BenchmarkExecutionServiceImpl implements BenchmarkExecutionUseCase 
     private void executeRun(UUID benchmarkId, UUID runId, String k6Instructions) {
 
         String k6ContainerId = null;
+        Path k6ScriptFile = null;
         boolean metricsStarted = false;
         boolean metricsStopped = false;
         try {
@@ -129,7 +134,13 @@ public class BenchmarkExecutionServiceImpl implements BenchmarkExecutionUseCase 
                 return;
             }
 
-            k6ContainerId = containerPort.startContainer(k6StartRequest(k6Instructions));
+            k6ScriptFile = createTempK6Script(k6Instructions);
+
+            if (!runContext.isActive(benchmarkId, runId)) {
+                return;
+            }
+
+            k6ContainerId = containerPort.startContainer(k6StartRequest(k6ScriptFile));
             if (runContext.setK6ContainerId(k6ContainerId).isEmpty()) {
                 return;
             }
@@ -154,6 +165,7 @@ public class BenchmarkExecutionServiceImpl implements BenchmarkExecutionUseCase 
                 cleanupCancelledRun(k6ContainerId, metricsStarted, metricsStopped);
             }
             runContext.deactivateIfMatch(benchmarkId, runId);
+            deleteTempFileSilently(k6ScriptFile);
         }
     }
 
@@ -200,13 +212,13 @@ public class BenchmarkExecutionServiceImpl implements BenchmarkExecutionUseCase 
         }
     }
 
-    private ContainerStartRequest k6StartRequest(String k6Instructions) {
+    private ContainerStartRequest k6StartRequest(Path scriptFile) {
         return new ContainerStartRequest(
                 k6Image,
-                Map.of("K6_SCRIPT", k6Instructions),
                 Map.of(),
+                Map.of(scriptFile.toAbsolutePath().toString(), K6_SCRIPT_CONTAINER_PATH),
                 k6Network,
-                List.of("run", "-"));
+                List.of("run", K6_SCRIPT_CONTAINER_PATH));
     }
 
     private boolean waitForContainerToComplete(UUID benchmarkId, UUID runId, String containerId) {
@@ -222,7 +234,11 @@ public class BenchmarkExecutionServiceImpl implements BenchmarkExecutionUseCase 
             }
 
             Long exitCode = containerPort.getContainerExitCode(containerId);
-            if (exitCode != null && exitCode != 0L) {
+            if (exitCode == null) {
+                throw new AgentException("K6 container exited but no exit code was available");
+            }
+
+            if (exitCode != 0L) {
                 throw new AgentException("K6 container exited with code " + exitCode);
             }
             return true;
@@ -279,6 +295,28 @@ public class BenchmarkExecutionServiceImpl implements BenchmarkExecutionUseCase 
         stopContainerSilently(k6ContainerId);
         if (metricsStarted && !metricsStopped) {
             stopMetricsSilently();
+        }
+    }
+
+    private Path createTempK6Script(String k6Instructions) {
+        try {
+            Path scriptFile = Files.createTempFile("viplev-k6-", ".js");
+            Files.writeString(scriptFile, k6Instructions);
+            return scriptFile;
+        } catch (IOException e) {
+            throw new AgentException("Failed to write temporary k6 script file", e);
+        }
+    }
+
+    private void deleteTempFileSilently(Path scriptFile) {
+        if (scriptFile == null) {
+            return;
+        }
+
+        try {
+            Files.deleteIfExists(scriptFile);
+        } catch (IOException e) {
+            log.warn("Failed to delete temporary k6 script file {}", scriptFile, e);
         }
     }
 

--- a/src/main/java/dk/viplev/agent/domain/services/BenchmarkExecutionServiceImpl.java
+++ b/src/main/java/dk/viplev/agent/domain/services/BenchmarkExecutionServiceImpl.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -83,28 +84,53 @@ public class BenchmarkExecutionServiceImpl implements BenchmarkExecutionUseCase 
             return;
         }
 
-        runExecutor.submit(() -> executeRun(benchmarkId, runId, k6Instructions));
+        try {
+            runExecutor.submit(() -> executeRun(benchmarkId, runId, k6Instructions));
+        } catch (RejectedExecutionException e) {
+            log.error("Failed to submit benchmark execution for benchmark={} run={}", benchmarkId, runId, e);
+            if (runContext.deactivateIfMatch(benchmarkId, runId).isPresent()) {
+                viplevApiPort.updateRunStatus(benchmarkId, runId,
+                        statusUpdate(BenchmarkRunStatusUpdateDTO.StatusEnum.FAILED,
+                                "Failed to schedule benchmark execution: " + e.getMessage()));
+            }
+        }
     }
 
     private void executeRun(UUID benchmarkId, UUID runId, String k6Instructions) {
 
         String k6ContainerId = null;
         boolean metricsStarted = false;
+        boolean metricsStopped = false;
         try {
+            if (!runContext.isActive(benchmarkId, runId)) {
+                return;
+            }
+
             if (k6Instructions == null || k6Instructions.isBlank()) {
                 throw new AgentException("k6Instructions are required for startRun");
             }
 
+            if (!runContext.isActive(benchmarkId, runId)) {
+                return;
+            }
+
             viplevApiPort.updateRunStatus(benchmarkId, runId, statusUpdate(BenchmarkRunStatusUpdateDTO.StatusEnum.STARTED, null));
+
+            if (!runContext.isActive(benchmarkId, runId)) {
+                return;
+            }
 
             metricsStarted = metricCollectorAdapter.startCollection(benchmarkId, runId);
             if (!metricsStarted) {
                 throw new AgentException("Failed to start metric collection");
             }
 
+            if (!runContext.isActive(benchmarkId, runId)) {
+                return;
+            }
+
             k6ContainerId = containerPort.startContainer(k6StartRequest(k6Instructions));
             if (runContext.setK6ContainerId(k6ContainerId).isEmpty()) {
-                containerPort.stopContainer(k6ContainerId);
                 return;
             }
 
@@ -118,11 +144,15 @@ public class BenchmarkExecutionServiceImpl implements BenchmarkExecutionUseCase 
             }
 
             stopMetricsSilently();
+            metricsStopped = true;
             sendEmptyPerformanceMetrics(benchmarkId, runId);
             viplevApiPort.updateRunStatus(benchmarkId, runId, statusUpdate(BenchmarkRunStatusUpdateDTO.StatusEnum.FINISHED, null));
         } catch (Exception e) {
             failRun(benchmarkId, runId, k6ContainerId, metricsStarted, e);
         } finally {
+            if (!runContext.isActive(benchmarkId, runId)) {
+                cleanupCancelledRun(k6ContainerId, metricsStarted, metricsStopped);
+            }
             runContext.deactivateIfMatch(benchmarkId, runId);
         }
     }
@@ -148,14 +178,25 @@ public class BenchmarkExecutionServiceImpl implements BenchmarkExecutionUseCase 
         }
 
         var run = runToStop.get();
+        String stopFailureReason = null;
 
         try {
             if (run.k6ContainerId() != null) {
                 containerPort.stopContainer(run.k6ContainerId());
             }
+        } catch (Exception e) {
+            stopFailureReason = e.getMessage() == null ? "Failed to stop K6 container" : e.getMessage();
+            log.warn("Failed to stop K6 container for benchmark={} run={}", benchmarkId, runId, e);
         } finally {
             stopMetricsSilently();
-            viplevApiPort.updateRunStatus(benchmarkId, runId, statusUpdate(BenchmarkRunStatusUpdateDTO.StatusEnum.STOPPED, null));
+            if (stopFailureReason == null) {
+                viplevApiPort.updateRunStatus(benchmarkId, runId,
+                        statusUpdate(BenchmarkRunStatusUpdateDTO.StatusEnum.STOPPED, null));
+            } else {
+                viplevApiPort.updateRunStatus(benchmarkId, runId,
+                        statusUpdate(BenchmarkRunStatusUpdateDTO.StatusEnum.FAILED,
+                                "Failed to stop benchmark run: " + stopFailureReason));
+            }
         }
     }
 
@@ -219,6 +260,25 @@ public class BenchmarkExecutionServiceImpl implements BenchmarkExecutionUseCase 
             metricCollectorAdapter.stopCollection();
         } catch (Exception e) {
             log.warn("Failed to stop metric collection cleanly", e);
+        }
+    }
+
+    private void stopContainerSilently(String containerId) {
+        if (containerId == null) {
+            return;
+        }
+
+        try {
+            containerPort.stopContainer(containerId);
+        } catch (Exception e) {
+            log.warn("Failed to stop K6 container {} during cleanup", containerId, e);
+        }
+    }
+
+    private void cleanupCancelledRun(String k6ContainerId, boolean metricsStarted, boolean metricsStopped) {
+        stopContainerSilently(k6ContainerId);
+        if (metricsStarted && !metricsStopped) {
+            stopMetricsSilently();
         }
     }
 

--- a/src/main/java/dk/viplev/agent/port/inbound/BenchmarkExecutionUseCase.java
+++ b/src/main/java/dk/viplev/agent/port/inbound/BenchmarkExecutionUseCase.java
@@ -1,0 +1,10 @@
+package dk.viplev.agent.port.inbound;
+
+import java.util.UUID;
+
+public interface BenchmarkExecutionUseCase {
+
+    void startRun(UUID benchmarkId, UUID runId, String k6Instructions);
+
+    void stopRun(UUID benchmarkId, UUID runId);
+}

--- a/src/main/java/dk/viplev/agent/port/outbound/container/ContainerPort.java
+++ b/src/main/java/dk/viplev/agent/port/outbound/container/ContainerPort.java
@@ -18,5 +18,9 @@ public interface ContainerPort {
 
     void stopContainer(String containerId);
 
+    boolean isContainerRunning(String containerId);
+
+    Long getContainerExitCode(String containerId);
+
     void watchContainerEvents(Consumer<ContainerEvent> callback);
 }

--- a/src/main/java/dk/viplev/agent/port/outbound/rest/ViplevApiPort.java
+++ b/src/main/java/dk/viplev/agent/port/outbound/rest/ViplevApiPort.java
@@ -1,6 +1,7 @@
 package dk.viplev.agent.port.outbound.rest;
 
 import dk.viplev.agent.generated.model.BenchmarkRunStatusUpdateDTO;
+import dk.viplev.agent.generated.model.BenchmarkDTO;
 import dk.viplev.agent.generated.model.MessageDTO;
 import dk.viplev.agent.generated.model.MetricPerformanceDTO;
 import dk.viplev.agent.generated.model.MetricResourceDTO;
@@ -12,6 +13,8 @@ import java.util.UUID;
 public interface ViplevApiPort {
 
     List<MessageDTO> pollMessages();
+
+    BenchmarkDTO getBenchmark(UUID benchmarkId);
 
     void registerServices(ServiceRegistrationDTO registration);
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -25,5 +25,15 @@ agent.node-exporter-image=${VIPLEV_NODE_EXPORTER_IMAGE:prom/node-exporter:v1.9.0
 agent.node-exporter-port=${VIPLEV_NODE_EXPORTER_PORT:9100}
 agent.cadvisor-port=${VIPLEV_CADVISOR_PORT:8080}
 
+# Message polling
+agent.message-polling-idle-interval-ms=${VIPLEV_MESSAGE_POLLING_IDLE_MS:15000}
+agent.message-polling-active-interval-ms=${VIPLEV_MESSAGE_POLLING_ACTIVE_MS:5000}
+agent.message-polling-tick-ms=${VIPLEV_MESSAGE_POLLING_TICK_MS:1000}
+
+# K6 execution
+agent.k6-image=${VIPLEV_K6_IMAGE:grafana/k6:0.53.0}
+agent.k6-network=${VIPLEV_K6_NETWORK:viplev_agent}
+agent.k6-completion-poll-interval-ms=${VIPLEV_K6_COMPLETION_POLL_INTERVAL_MS:1000}
+
 # Actuator
 management.endpoints.web.exposure.include=health,info

--- a/src/test/java/dk/viplev/agent/AgentApplicationTests.java
+++ b/src/test/java/dk/viplev/agent/AgentApplicationTests.java
@@ -2,6 +2,7 @@ package dk.viplev.agent;
 
 import dk.viplev.agent.port.outbound.container.ContainerPort;
 import dk.viplev.agent.port.outbound.discovery.NodeDiscoveryPort;
+import dk.viplev.agent.port.outbound.rest.ViplevApiPort;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
@@ -16,6 +17,9 @@ class AgentApplicationTests {
 
 	@MockitoBean
 	private NodeDiscoveryPort nodeDiscoveryPort;
+
+	@MockitoBean
+	private ViplevApiPort viplevApiPort;
 
 	@Test
 	void contextLoads() {

--- a/src/test/java/dk/viplev/agent/adapter/inbound/scheduling/MessagePollingAdapterTest.java
+++ b/src/test/java/dk/viplev/agent/adapter/inbound/scheduling/MessagePollingAdapterTest.java
@@ -13,10 +13,12 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.List;
 import java.util.UUID;
+import java.util.stream.IntStream;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -151,5 +153,14 @@ class MessagePollingAdapterTest {
 
         verify(benchmarkExecutionUseCase, never()).startRun(any(), any(), any());
         verify(benchmarkExecutionUseCase, never()).stopRun(any(), any());
+    }
+
+    @Test
+    void pollingExceptionDoesNotDelayRetryByInterval() {
+        doThrow(new RuntimeException("boom")).when(viplevApiPort).pollMessages();
+
+        IntStream.range(0, 3).forEach(i -> adapter.pollMessagesSafely(1_000 + i));
+
+        verify(viplevApiPort, times(3)).pollMessages();
     }
 }

--- a/src/test/java/dk/viplev/agent/adapter/inbound/scheduling/MessagePollingAdapterTest.java
+++ b/src/test/java/dk/viplev/agent/adapter/inbound/scheduling/MessagePollingAdapterTest.java
@@ -1,0 +1,155 @@
+package dk.viplev.agent.adapter.inbound.scheduling;
+
+import dk.viplev.agent.domain.model.RunContext;
+import dk.viplev.agent.generated.model.BenchmarkDTO;
+import dk.viplev.agent.generated.model.MessageDTO;
+import dk.viplev.agent.port.inbound.BenchmarkExecutionUseCase;
+import dk.viplev.agent.port.outbound.rest.ViplevApiPort;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class MessagePollingAdapterTest {
+
+    @Mock
+    private ViplevApiPort viplevApiPort;
+
+    @Mock
+    private BenchmarkExecutionUseCase benchmarkExecutionUseCase;
+
+    private RunContext runContext;
+    private MessagePollingAdapter adapter;
+
+    private static final UUID BENCHMARK_ID = UUID.fromString("11111111-1111-1111-1111-111111111111");
+    private static final UUID RUN_ID = UUID.fromString("22222222-2222-2222-2222-222222222222");
+
+    @BeforeEach
+    void setUp() {
+        runContext = new RunContext();
+        adapter = new MessagePollingAdapter(viplevApiPort, benchmarkExecutionUseCase, runContext, 15_000, 5_000);
+    }
+
+    @Test
+    void shouldPollImmediatelyWhenNeverPolledBefore() {
+        when(viplevApiPort.pollMessages()).thenReturn(List.of());
+
+        adapter.pollMessagesSafely(1_000);
+
+        verify(viplevApiPort).pollMessages();
+    }
+
+    @Test
+    void shouldRespectIdlePollingInterval() {
+        when(viplevApiPort.pollMessages()).thenReturn(List.of());
+
+        adapter.pollMessagesSafely(1_000);
+        adapter.pollMessagesSafely(10_000);
+
+        verify(viplevApiPort).pollMessages();
+    }
+
+    @Test
+    void shouldUseActiveIntervalWhenRunIsActive() {
+        when(viplevApiPort.pollMessages()).thenReturn(List.of());
+        runContext.activate(BENCHMARK_ID, RUN_ID);
+
+        adapter.pollMessagesSafely(1_000);
+        adapter.pollMessagesSafely(5_500);
+
+        verify(viplevApiPort, org.mockito.Mockito.times(1)).pollMessages();
+        adapter.pollMessagesSafely(6_100);
+        verify(viplevApiPort, org.mockito.Mockito.times(2)).pollMessages();
+    }
+
+    @Test
+    void pendingStart_fetchesBenchmarkAndStartsRun() {
+        var message = new MessageDTO()
+                .benchmarkId(BENCHMARK_ID)
+                .runId(RUN_ID)
+                .messageType(MessageDTO.MessageTypeEnum.PENDING_START);
+
+        when(viplevApiPort.pollMessages()).thenReturn(List.of(message));
+        when(viplevApiPort.getBenchmark(BENCHMARK_ID)).thenReturn(new BenchmarkDTO().k6Instructions("script"));
+
+        adapter.pollMessagesSafely(1_000);
+
+        verify(viplevApiPort).getBenchmark(BENCHMARK_ID);
+        verify(benchmarkExecutionUseCase).startRun(BENCHMARK_ID, RUN_ID, "script");
+    }
+
+    @Test
+    void pendingStop_stopsRun() {
+        var message = new MessageDTO()
+                .benchmarkId(BENCHMARK_ID)
+                .runId(RUN_ID)
+                .messageType(MessageDTO.MessageTypeEnum.PENDING_STOP);
+
+        when(viplevApiPort.pollMessages()).thenReturn(List.of(message));
+
+        adapter.pollMessagesSafely(1_000);
+
+        verify(benchmarkExecutionUseCase).stopRun(BENCHMARK_ID, RUN_ID);
+    }
+
+    @Test
+    void handlesOnlyFirstMessageWhenListContainsMultiple() {
+        var first = new MessageDTO()
+                .benchmarkId(BENCHMARK_ID)
+                .runId(RUN_ID)
+                .messageType(MessageDTO.MessageTypeEnum.PENDING_STOP);
+        var second = new MessageDTO()
+                .benchmarkId(UUID.randomUUID())
+                .runId(UUID.randomUUID())
+                .messageType(MessageDTO.MessageTypeEnum.PENDING_START);
+
+        when(viplevApiPort.pollMessages()).thenReturn(List.of(first, second));
+
+        adapter.pollMessagesSafely(1_000);
+
+        verify(benchmarkExecutionUseCase).stopRun(BENCHMARK_ID, RUN_ID);
+        verify(benchmarkExecutionUseCase, never()).startRun(any(), any(), any());
+    }
+
+    @Test
+    void ignoresMessageWithNullType() {
+        var message = new MessageDTO().benchmarkId(BENCHMARK_ID).runId(RUN_ID);
+        when(viplevApiPort.pollMessages()).thenReturn(List.of(message));
+
+        adapter.pollMessagesSafely(1_000);
+
+        verify(benchmarkExecutionUseCase, never()).startRun(any(), any(), any());
+        verify(benchmarkExecutionUseCase, never()).stopRun(any(), any());
+    }
+
+    @Test
+    void ignoresMessageWithNullIds() {
+        var message = new MessageDTO().messageType(MessageDTO.MessageTypeEnum.PENDING_START);
+        when(viplevApiPort.pollMessages()).thenReturn(List.of(message));
+
+        adapter.pollMessagesSafely(1_000);
+
+        verify(benchmarkExecutionUseCase, never()).startRun(any(), any(), any());
+    }
+
+    @Test
+    void pollingExceptionDoesNotPropagate() {
+        doThrow(new RuntimeException("boom")).when(viplevApiPort).pollMessages();
+
+        adapter.pollMessagesSafely(1_000);
+
+        verify(benchmarkExecutionUseCase, never()).startRun(any(), any(), any());
+        verify(benchmarkExecutionUseCase, never()).stopRun(any(), any());
+    }
+}

--- a/src/test/java/dk/viplev/agent/adapter/inbound/scheduling/MetricCollectorAdapterTest.java
+++ b/src/test/java/dk/viplev/agent/adapter/inbound/scheduling/MetricCollectorAdapterTest.java
@@ -1,31 +1,21 @@
 package dk.viplev.agent.adapter.inbound.scheduling;
 
-import dk.viplev.agent.generated.model.MessageDTO;
 import dk.viplev.agent.port.inbound.MetricCollectionUseCase;
-import dk.viplev.agent.port.outbound.rest.ViplevApiPort;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.util.List;
 import java.util.UUID;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class MetricCollectorAdapterTest {
 
     @Mock
     private MetricCollectionUseCase metricCollectionUseCase;
-
-    @Mock
-    private ViplevApiPort viplevApiPort;
 
     private MetricCollectorAdapter adapter;
 
@@ -34,7 +24,7 @@ class MetricCollectorAdapterTest {
 
     @BeforeEach
     void setUp() {
-        adapter = new MetricCollectorAdapter(metricCollectionUseCase, viplevApiPort);
+        adapter = new MetricCollectorAdapter(metricCollectionUseCase);
     }
 
     @Test
@@ -49,104 +39,5 @@ class MetricCollectorAdapterTest {
         adapter.stopCollection();
 
         verify(metricCollectionUseCase).stopCollection();
-    }
-
-    @Test
-    void polling_pendingStart_startsCollection() {
-        var message = new MessageDTO()
-                .benchmarkId(BENCHMARK_ID)
-                .runId(RUN_ID)
-                .messageType(MessageDTO.MessageTypeEnum.PENDING_START);
-        when(viplevApiPort.pollMessages()).thenReturn(List.of(message));
-        when(metricCollectionUseCase.startCollection(BENCHMARK_ID, RUN_ID)).thenReturn(true);
-
-        adapter.pollMessagesSafely();
-
-        verify(metricCollectionUseCase).startCollection(BENCHMARK_ID, RUN_ID);
-        verify(viplevApiPort).updateRunStatus(any(), any(), any());
-    }
-
-    @Test
-    void polling_pendingStop_stopsCollection() {
-        var message = new MessageDTO()
-                .benchmarkId(BENCHMARK_ID)
-                .runId(RUN_ID)
-                .messageType(MessageDTO.MessageTypeEnum.PENDING_STOP);
-        when(viplevApiPort.pollMessages()).thenReturn(List.of(message));
-        when(metricCollectionUseCase.stopCollection()).thenReturn(true);
-
-        adapter.pollMessagesSafely();
-
-        verify(metricCollectionUseCase).stopCollection();
-        verify(viplevApiPort).updateRunStatus(any(), any(), any());
-    }
-
-    @Test
-    void polling_pendingStart_withoutStateTransition_doesNotUpdateRunStatus() {
-        var message = new MessageDTO()
-                .benchmarkId(BENCHMARK_ID)
-                .runId(RUN_ID)
-                .messageType(MessageDTO.MessageTypeEnum.PENDING_START);
-        when(viplevApiPort.pollMessages()).thenReturn(List.of(message));
-        when(metricCollectionUseCase.startCollection(BENCHMARK_ID, RUN_ID)).thenReturn(false);
-
-        adapter.pollMessagesSafely();
-
-        verify(metricCollectionUseCase).startCollection(BENCHMARK_ID, RUN_ID);
-        verify(viplevApiPort, never()).updateRunStatus(any(), any(), any());
-    }
-
-    @Test
-    void polling_pendingStop_withoutStateTransition_doesNotUpdateRunStatus() {
-        var message = new MessageDTO()
-                .benchmarkId(BENCHMARK_ID)
-                .runId(RUN_ID)
-                .messageType(MessageDTO.MessageTypeEnum.PENDING_STOP);
-        when(viplevApiPort.pollMessages()).thenReturn(List.of(message));
-        when(metricCollectionUseCase.stopCollection()).thenReturn(false);
-
-        adapter.pollMessagesSafely();
-
-        verify(metricCollectionUseCase).stopCollection();
-        verify(viplevApiPort, never()).updateRunStatus(any(), any(), any());
-    }
-
-    @Test
-    void polling_apiError_doesNotCrash() {
-        doThrow(new RuntimeException("Connection refused")).when(viplevApiPort).pollMessages();
-
-        // Must not throw
-        adapter.pollMessagesSafely();
-
-        verify(metricCollectionUseCase, never()).startCollection(any(), any());
-        verify(metricCollectionUseCase, never()).stopCollection();
-    }
-
-    @Test
-    void handleMessage_pendingStartWithNullBenchmarkId_ignoresMessage() {
-        var message = new MessageDTO()
-                .benchmarkId(null)
-                .runId(RUN_ID)
-                .messageType(MessageDTO.MessageTypeEnum.PENDING_START);
-        when(viplevApiPort.pollMessages()).thenReturn(List.of(message));
-
-        adapter.pollMessagesSafely();
-
-        verify(metricCollectionUseCase, never()).startCollection(any(), any());
-        verify(viplevApiPort, never()).updateRunStatus(any(), any(), any());
-    }
-
-    @Test
-    void handleMessage_pendingStartWithNullRunId_ignoresMessage() {
-        var message = new MessageDTO()
-                .benchmarkId(BENCHMARK_ID)
-                .runId(null)
-                .messageType(MessageDTO.MessageTypeEnum.PENDING_START);
-        when(viplevApiPort.pollMessages()).thenReturn(List.of(message));
-
-        adapter.pollMessagesSafely();
-
-        verify(metricCollectionUseCase, never()).startCollection(any(), any());
-        verify(viplevApiPort, never()).updateRunStatus(any(), any(), any());
     }
 }

--- a/src/test/java/dk/viplev/agent/adapter/outbound/container/docker/DockerContainerAdapterTest.java
+++ b/src/test/java/dk/viplev/agent/adapter/outbound/container/docker/DockerContainerAdapterTest.java
@@ -227,6 +227,36 @@ class DockerContainerAdapterTest {
     }
 
     @Test
+    void isContainerRunning_returnsTrueWhenRunning() {
+        var inspectCmd = mock(InspectContainerCmd.class);
+        when(dockerClient.inspectContainerCmd("container1")).thenReturn(inspectCmd);
+
+        var inspect = mock(InspectContainerResponse.class);
+        when(inspectCmd.exec()).thenReturn(inspect);
+
+        var state = mock(InspectContainerResponse.ContainerState.class);
+        when(inspect.getState()).thenReturn(state);
+        when(state.getRunning()).thenReturn(true);
+
+        assertThat(adapter.isContainerRunning("container1")).isTrue();
+    }
+
+    @Test
+    void getContainerExitCode_returnsExitCodeFromInspect() {
+        var inspectCmd = mock(InspectContainerCmd.class);
+        when(dockerClient.inspectContainerCmd("container1")).thenReturn(inspectCmd);
+
+        var inspect = mock(InspectContainerResponse.class);
+        when(inspectCmd.exec()).thenReturn(inspect);
+
+        var state = mock(InspectContainerResponse.ContainerState.class);
+        when(inspect.getState()).thenReturn(state);
+        when(state.getExitCodeLong()).thenReturn(42L);
+
+        assertThat(adapter.getContainerExitCode("container1")).isEqualTo(42L);
+    }
+
+    @Test
     @SuppressWarnings("unchecked")
     void watchContainerEvents_forwardsStartEvent() throws InterruptedException {
         var eventsCmd = mockEventsCmd();

--- a/src/test/java/dk/viplev/agent/adapter/outbound/rest/ViplevApiAdapterTest.java
+++ b/src/test/java/dk/viplev/agent/adapter/outbound/rest/ViplevApiAdapterTest.java
@@ -2,7 +2,9 @@ package dk.viplev.agent.adapter.outbound.rest;
 
 import dk.viplev.agent.domain.exception.ViplevApiException;
 import dk.viplev.agent.generated.api.AgentApi;
+import dk.viplev.agent.generated.api.BenchmarkApi;
 import dk.viplev.agent.generated.model.BenchmarkRunStatusUpdateDTO;
+import dk.viplev.agent.generated.model.BenchmarkDTO;
 import dk.viplev.agent.generated.model.MessageDTO;
 import dk.viplev.agent.generated.model.MetricPerformanceDTO;
 import dk.viplev.agent.generated.model.MetricResourceDTO;
@@ -32,6 +34,9 @@ class ViplevApiAdapterTest {
     @Mock
     private AgentApi agentApi;
 
+    @Mock
+    private BenchmarkApi benchmarkApi;
+
     private final UUID environmentId = UUID.randomUUID();
     private final UUID benchmarkId = UUID.randomUUID();
     private final UUID runId = UUID.randomUUID();
@@ -40,7 +45,7 @@ class ViplevApiAdapterTest {
 
     @BeforeEach
     void setUp() {
-        adapter = new ViplevApiAdapter(agentApi, environmentId);
+        adapter = new ViplevApiAdapter(agentApi, benchmarkApi, environmentId);
     }
 
     @Test
@@ -61,6 +66,17 @@ class ViplevApiAdapterTest {
         adapter.registerServices(registration);
 
         verify(agentApi).registerServices(environmentId, registration);
+    }
+
+    @Test
+    void getBenchmark_delegatesToBenchmarkApi() {
+        var benchmark = new BenchmarkDTO().name("benchmark");
+        when(benchmarkApi.getBenchmark(benchmarkId, environmentId)).thenReturn(benchmark);
+
+        var result = adapter.getBenchmark(benchmarkId);
+
+        assertThat(result).isEqualTo(benchmark);
+        verify(benchmarkApi).getBenchmark(benchmarkId, environmentId);
     }
 
     @Test
@@ -147,5 +163,16 @@ class ViplevApiAdapterTest {
                 .isInstanceOf(ViplevApiException.class)
                 .hasFieldOrPropertyWithValue("statusCode", 502)
                 .hasMessageContaining("Failed to send performance metrics");
+    }
+
+    @Test
+    void getBenchmark_wrapsClientError() {
+        when(benchmarkApi.getBenchmark(benchmarkId, environmentId))
+                .thenThrow(new HttpClientErrorException(HttpStatus.NOT_FOUND, "Not Found"));
+
+        assertThatThrownBy(() -> adapter.getBenchmark(benchmarkId))
+                .isInstanceOf(ViplevApiException.class)
+                .hasFieldOrPropertyWithValue("statusCode", 404)
+                .hasMessageContaining("Failed to fetch benchmark");
     }
 }

--- a/src/test/java/dk/viplev/agent/config/ViplevApiConfigTest.java
+++ b/src/test/java/dk/viplev/agent/config/ViplevApiConfigTest.java
@@ -1,6 +1,7 @@
 package dk.viplev.agent.config;
 
 import dk.viplev.agent.generated.api.AgentApi;
+import dk.viplev.agent.generated.api.BenchmarkApi;
 import dk.viplev.agent.generated.invoker.ApiClient;
 import dk.viplev.agent.generated.invoker.auth.HttpBearerAuth;
 import org.junit.jupiter.api.Test;
@@ -30,6 +31,15 @@ class ViplevApiConfigTest {
         AgentApi agentApi = config.agentApi(client);
 
         assertThat(agentApi.getApiClient()).isSameAs(client);
+    }
+
+    @Test
+    void benchmarkApi_usesProvidedApiClient() {
+        ApiClient client = config.viplevApiClient("https://viplev.example.com", "test-token");
+
+        BenchmarkApi benchmarkApi = config.benchmarkApi(client);
+
+        assertThat(benchmarkApi.getApiClient()).isSameAs(client);
     }
 
     @Test

--- a/src/test/java/dk/viplev/agent/domain/exception/ExceptionTest.java
+++ b/src/test/java/dk/viplev/agent/domain/exception/ExceptionTest.java
@@ -25,7 +25,7 @@ class ExceptionTest {
     void viplevApiExceptionPreservesStatusCode() {
         var ex = new ViplevApiException("not found", 404);
         assertThat(ex.getMessage()).isEqualTo("not found");
-        assertThat(ex.getStatusCode()).isEqualTo(404);
+        assertThat(ex).hasFieldOrPropertyWithValue("statusCode", 404);
         assertThat(ex).isInstanceOf(AgentException.class);
     }
 
@@ -33,7 +33,7 @@ class ExceptionTest {
     void viplevApiExceptionWithCause() {
         var cause = new RuntimeException("connection refused");
         var ex = new ViplevApiException("api error", 503, cause);
-        assertThat(ex.getStatusCode()).isEqualTo(503);
+        assertThat(ex).hasFieldOrPropertyWithValue("statusCode", 503);
         assertThat(ex.getCause()).isSameAs(cause);
     }
 

--- a/src/test/java/dk/viplev/agent/domain/model/RunContextTest.java
+++ b/src/test/java/dk/viplev/agent/domain/model/RunContextTest.java
@@ -1,0 +1,59 @@
+package dk.viplev.agent.domain.model;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class RunContextTest {
+
+    private static final UUID BENCHMARK_ID = UUID.fromString("11111111-1111-1111-1111-111111111111");
+    private static final UUID RUN_ID = UUID.fromString("22222222-2222-2222-2222-222222222222");
+
+    @Test
+    void activateSetsRunAsActive() {
+        RunContext context = new RunContext();
+
+        boolean activated = context.activate(BENCHMARK_ID, RUN_ID);
+
+        assertThat(activated).isTrue();
+        assertThat(context.isActive()).isTrue();
+        assertThat(context.isActive(BENCHMARK_ID, RUN_ID)).isTrue();
+    }
+
+    @Test
+    void activateFailsWhenAlreadyActive() {
+        RunContext context = new RunContext();
+        context.activate(BENCHMARK_ID, RUN_ID);
+
+        boolean activated = context.activate(UUID.randomUUID(), UUID.randomUUID());
+
+        assertThat(activated).isFalse();
+        assertThat(context.isActive(BENCHMARK_ID, RUN_ID)).isTrue();
+    }
+
+    @Test
+    void setContainerIdUpdatesActiveRun() {
+        RunContext context = new RunContext();
+        context.activate(BENCHMARK_ID, RUN_ID);
+
+        var updated = context.setK6ContainerId("k6-1");
+
+        assertThat(updated).isPresent();
+        assertThat(updated.get().k6ContainerId()).isEqualTo("k6-1");
+    }
+
+    @Test
+    void deactivateIfMatchClearsOnlyMatchingRun() {
+        RunContext context = new RunContext();
+        context.activate(BENCHMARK_ID, RUN_ID);
+
+        var wrongDeactivate = context.deactivateIfMatch(UUID.randomUUID(), UUID.randomUUID());
+        var rightDeactivate = context.deactivateIfMatch(BENCHMARK_ID, RUN_ID);
+
+        assertThat(wrongDeactivate).isEmpty();
+        assertThat(rightDeactivate).isPresent();
+        assertThat(context.isActive()).isFalse();
+    }
+}

--- a/src/test/java/dk/viplev/agent/domain/services/BenchmarkExecutionServiceImplTest.java
+++ b/src/test/java/dk/viplev/agent/domain/services/BenchmarkExecutionServiceImplTest.java
@@ -14,9 +14,12 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.List;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.UUID;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -135,6 +138,69 @@ class BenchmarkExecutionServiceImplTest {
         assertThat(statusCaptor.getValue().getStatusReason()).contains("k6Instructions");
     }
 
+    @Test
+    void startRun_submitRejected_deactivatesRunAndUpdatesFailed() {
+        service = new BenchmarkExecutionServiceImpl(
+                runContext,
+                viplevApiPort,
+                metricCollectorAdapter,
+                containerPort,
+                "grafana/k6:latest",
+                "viplev_agent",
+                0,
+                new RejectingExecutorService());
+
+        service.startRun(BENCHMARK_ID, RUN_ID, "script");
+
+        var statusCaptor = ArgumentCaptor.forClass(BenchmarkRunStatusUpdateDTO.class);
+        verify(viplevApiPort).updateRunStatus(any(), any(), statusCaptor.capture());
+        assertThat(statusCaptor.getValue().getStatus()).isEqualTo(BenchmarkRunStatusUpdateDTO.StatusEnum.FAILED);
+        assertThat(statusCaptor.getValue().getStatusReason()).contains("Failed to schedule benchmark execution");
+        assertThat(runContext.isActive()).isFalse();
+        verify(metricCollectorAdapter, never()).startCollection(any(), any());
+        verify(containerPort, never()).startContainer(any());
+    }
+
+    @Test
+    void stopRun_whenContainerStopFails_updatesFailed() {
+        runContext.activate(BENCHMARK_ID, RUN_ID);
+        runContext.setK6ContainerId("k6-id");
+        doThrow(new RuntimeException("docker stop failed")).when(containerPort).stopContainer("k6-id");
+
+        service.stopRun(BENCHMARK_ID, RUN_ID);
+
+        var statusCaptor = ArgumentCaptor.forClass(BenchmarkRunStatusUpdateDTO.class);
+        verify(viplevApiPort).updateRunStatus(any(), any(), statusCaptor.capture());
+        assertThat(statusCaptor.getValue().getStatus()).isEqualTo(BenchmarkRunStatusUpdateDTO.StatusEnum.FAILED);
+        assertThat(statusCaptor.getValue().getStatusReason()).contains("Failed to stop benchmark run");
+        verify(metricCollectorAdapter).stopCollection();
+    }
+
+    @Test
+    void stopBeforeExecutorRuns_preventsStartTransition() {
+        var queuedExecutor = new QueuedExecutorService();
+        service = new BenchmarkExecutionServiceImpl(
+                runContext,
+                viplevApiPort,
+                metricCollectorAdapter,
+                containerPort,
+                "grafana/k6:latest",
+                "viplev_agent",
+                0,
+                queuedExecutor);
+
+        service.startRun(BENCHMARK_ID, RUN_ID, "script");
+        service.stopRun(BENCHMARK_ID, RUN_ID);
+        queuedExecutor.runNext();
+
+        var statusCaptor = ArgumentCaptor.forClass(BenchmarkRunStatusUpdateDTO.class);
+        verify(viplevApiPort).updateRunStatus(any(), any(), statusCaptor.capture());
+        assertThat(statusCaptor.getValue().getStatus()).isEqualTo(BenchmarkRunStatusUpdateDTO.StatusEnum.STOPPED);
+        verify(metricCollectorAdapter, never()).startCollection(any(), any());
+        verify(containerPort, never()).startContainer(any());
+        assertThat(runContext.isActive()).isFalse();
+    }
+
     private static final class DirectExecutorService extends java.util.concurrent.AbstractExecutorService {
         private volatile boolean shutdown;
 
@@ -167,6 +233,84 @@ class BenchmarkExecutionServiceImplTest {
         @Override
         public void execute(Runnable command) {
             command.run();
+        }
+    }
+
+    private static final class RejectingExecutorService extends java.util.concurrent.AbstractExecutorService {
+        private volatile boolean shutdown;
+
+        @Override
+        public void shutdown() {
+            shutdown = true;
+        }
+
+        @Override
+        public List<Runnable> shutdownNow() {
+            shutdown = true;
+            return List.of();
+        }
+
+        @Override
+        public boolean isShutdown() {
+            return shutdown;
+        }
+
+        @Override
+        public boolean isTerminated() {
+            return shutdown;
+        }
+
+        @Override
+        public boolean awaitTermination(long timeout, java.util.concurrent.TimeUnit unit) {
+            return true;
+        }
+
+        @Override
+        public void execute(Runnable command) {
+            throw new RejectedExecutionException("executor is shutting down");
+        }
+    }
+
+    private static final class QueuedExecutorService extends java.util.concurrent.AbstractExecutorService {
+        private volatile boolean shutdown;
+        private Runnable next;
+
+        @Override
+        public void shutdown() {
+            shutdown = true;
+        }
+
+        @Override
+        public List<Runnable> shutdownNow() {
+            shutdown = true;
+            return List.of();
+        }
+
+        @Override
+        public boolean isShutdown() {
+            return shutdown;
+        }
+
+        @Override
+        public boolean isTerminated() {
+            return shutdown;
+        }
+
+        @Override
+        public boolean awaitTermination(long timeout, java.util.concurrent.TimeUnit unit) {
+            return true;
+        }
+
+        @Override
+        public void execute(Runnable command) {
+            this.next = command;
+        }
+
+        void runNext() {
+            if (next != null) {
+                next.run();
+                next = null;
+            }
         }
     }
 }

--- a/src/test/java/dk/viplev/agent/domain/services/BenchmarkExecutionServiceImplTest.java
+++ b/src/test/java/dk/viplev/agent/domain/services/BenchmarkExecutionServiceImplTest.java
@@ -1,0 +1,172 @@
+package dk.viplev.agent.domain.services;
+
+import dk.viplev.agent.adapter.inbound.scheduling.MetricCollectorAdapter;
+import dk.viplev.agent.domain.model.ContainerStartRequest;
+import dk.viplev.agent.domain.model.RunContext;
+import dk.viplev.agent.generated.model.BenchmarkRunStatusUpdateDTO;
+import dk.viplev.agent.port.outbound.container.ContainerPort;
+import dk.viplev.agent.port.outbound.rest.ViplevApiPort;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.UUID;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class BenchmarkExecutionServiceImplTest {
+
+    @Mock
+    private ViplevApiPort viplevApiPort;
+
+    @Mock
+    private MetricCollectorAdapter metricCollectorAdapter;
+
+    @Mock
+    private ContainerPort containerPort;
+
+    private RunContext runContext;
+    private BenchmarkExecutionServiceImpl service;
+
+    private static final UUID BENCHMARK_ID = UUID.fromString("11111111-1111-1111-1111-111111111111");
+    private static final UUID RUN_ID = UUID.fromString("22222222-2222-2222-2222-222222222222");
+
+    @BeforeEach
+    void setUp() {
+        runContext = new RunContext();
+        service = new BenchmarkExecutionServiceImpl(
+                runContext,
+                viplevApiPort,
+                metricCollectorAdapter,
+                containerPort,
+                "grafana/k6:latest",
+                "viplev_agent",
+                0,
+                new DirectExecutorService());
+    }
+
+    @Test
+    void startRun_success_updatesStartedAndFinished() {
+        when(metricCollectorAdapter.startCollection(BENCHMARK_ID, RUN_ID)).thenReturn(true);
+        when(containerPort.startContainer(any(ContainerStartRequest.class))).thenReturn("k6-id");
+        when(containerPort.isContainerRunning("k6-id")).thenReturn(true).thenReturn(false);
+        when(containerPort.getContainerExitCode("k6-id")).thenReturn(0L);
+
+        service.startRun(BENCHMARK_ID, RUN_ID, "script");
+
+        var statusCaptor = ArgumentCaptor.forClass(BenchmarkRunStatusUpdateDTO.class);
+        verify(viplevApiPort, org.mockito.Mockito.times(2)).updateRunStatus(any(), any(), statusCaptor.capture());
+        assertThat(statusCaptor.getAllValues().get(0).getStatus()).isEqualTo(BenchmarkRunStatusUpdateDTO.StatusEnum.STARTED);
+        assertThat(statusCaptor.getAllValues().get(1).getStatus()).isEqualTo(BenchmarkRunStatusUpdateDTO.StatusEnum.FINISHED);
+        verify(metricCollectorAdapter).startCollection(BENCHMARK_ID, RUN_ID);
+        verify(metricCollectorAdapter).stopCollection();
+        verify(viplevApiPort).sendPerformanceMetrics(any(), any(), any());
+        assertThat(runContext.isActive()).isFalse();
+    }
+
+    @Test
+    void startRun_failure_updatesFailed() {
+        when(metricCollectorAdapter.startCollection(BENCHMARK_ID, RUN_ID)).thenReturn(true);
+        when(containerPort.startContainer(any(ContainerStartRequest.class))).thenReturn("k6-id");
+        when(containerPort.isContainerRunning("k6-id")).thenReturn(false);
+        when(containerPort.getContainerExitCode("k6-id")).thenReturn(137L);
+
+        service.startRun(BENCHMARK_ID, RUN_ID, "script");
+
+        var statusCaptor = ArgumentCaptor.forClass(BenchmarkRunStatusUpdateDTO.class);
+        verify(viplevApiPort, org.mockito.Mockito.times(2)).updateRunStatus(any(), any(), statusCaptor.capture());
+        assertThat(statusCaptor.getAllValues().get(0).getStatus()).isEqualTo(BenchmarkRunStatusUpdateDTO.StatusEnum.STARTED);
+        assertThat(statusCaptor.getAllValues().get(1).getStatus()).isEqualTo(BenchmarkRunStatusUpdateDTO.StatusEnum.FAILED);
+        assertThat(statusCaptor.getAllValues().get(1).getStatusReason()).contains("137");
+    }
+
+    @Test
+    void stopRun_activeRun_stopsContainerAndUpdatesStatus() {
+        runContext.activate(BENCHMARK_ID, RUN_ID);
+        runContext.setK6ContainerId("k6-id");
+
+        service.stopRun(BENCHMARK_ID, RUN_ID);
+
+        verify(containerPort).stopContainer("k6-id");
+        verify(metricCollectorAdapter).stopCollection();
+        var statusCaptor = ArgumentCaptor.forClass(BenchmarkRunStatusUpdateDTO.class);
+        verify(viplevApiPort).updateRunStatus(any(), any(), statusCaptor.capture());
+        assertThat(statusCaptor.getValue().getStatus()).isEqualTo(BenchmarkRunStatusUpdateDTO.StatusEnum.STOPPED);
+        assertThat(runContext.isActive()).isFalse();
+    }
+
+    @Test
+    void startRun_whenAlreadyActive_isIgnored() {
+        runContext.activate(BENCHMARK_ID, RUN_ID);
+
+        service.startRun(UUID.randomUUID(), UUID.randomUUID(), "script");
+
+        verify(viplevApiPort, never()).updateRunStatus(any(), any(), any());
+        verify(metricCollectorAdapter, never()).startCollection(any(), any());
+        verify(containerPort, never()).startContainer(any());
+    }
+
+    @Test
+    void stopRun_nonMatchingActiveRun_isIgnored() {
+        runContext.activate(BENCHMARK_ID, RUN_ID);
+
+        service.stopRun(UUID.randomUUID(), UUID.randomUUID());
+
+        verify(viplevApiPort, never()).updateRunStatus(any(), any(), any());
+        verify(containerPort, never()).stopContainer(any());
+        assertThat(runContext.isActive()).isTrue();
+    }
+
+    @Test
+    void startRun_blankInstructions_updatesFailed() {
+        service.startRun(BENCHMARK_ID, RUN_ID, " ");
+
+        var statusCaptor = ArgumentCaptor.forClass(BenchmarkRunStatusUpdateDTO.class);
+        verify(viplevApiPort).updateRunStatus(any(), any(), statusCaptor.capture());
+        assertThat(statusCaptor.getValue().getStatus()).isEqualTo(BenchmarkRunStatusUpdateDTO.StatusEnum.FAILED);
+        assertThat(statusCaptor.getValue().getStatusReason()).contains("k6Instructions");
+    }
+
+    private static final class DirectExecutorService extends java.util.concurrent.AbstractExecutorService {
+        private volatile boolean shutdown;
+
+        @Override
+        public void shutdown() {
+            shutdown = true;
+        }
+
+        @Override
+        public List<Runnable> shutdownNow() {
+            shutdown = true;
+            return List.of();
+        }
+
+        @Override
+        public boolean isShutdown() {
+            return shutdown;
+        }
+
+        @Override
+        public boolean isTerminated() {
+            return shutdown;
+        }
+
+        @Override
+        public boolean awaitTermination(long timeout, java.util.concurrent.TimeUnit unit) {
+            return true;
+        }
+
+        @Override
+        public void execute(Runnable command) {
+            command.run();
+        }
+    }
+}

--- a/src/test/java/dk/viplev/agent/domain/services/BenchmarkExecutionServiceImplTest.java
+++ b/src/test/java/dk/viplev/agent/domain/services/BenchmarkExecutionServiceImplTest.java
@@ -73,6 +73,14 @@ class BenchmarkExecutionServiceImplTest {
         verify(metricCollectorAdapter).stopCollection();
         verify(viplevApiPort).sendPerformanceMetrics(any(), any(), any());
         assertThat(runContext.isActive()).isFalse();
+
+        var requestCaptor = ArgumentCaptor.forClass(ContainerStartRequest.class);
+        verify(containerPort).startContainer(requestCaptor.capture());
+        var request = requestCaptor.getValue();
+        assertThat(request.command()).containsExactly("run", "/tmp/viplev-k6-script.js");
+        assertThat(request.volumes()).hasSize(1);
+        assertThat(request.volumes().values()).containsExactly("/tmp/viplev-k6-script.js");
+        assertThat(request.env()).isEmpty();
     }
 
     @Test
@@ -89,6 +97,22 @@ class BenchmarkExecutionServiceImplTest {
         assertThat(statusCaptor.getAllValues().get(0).getStatus()).isEqualTo(BenchmarkRunStatusUpdateDTO.StatusEnum.STARTED);
         assertThat(statusCaptor.getAllValues().get(1).getStatus()).isEqualTo(BenchmarkRunStatusUpdateDTO.StatusEnum.FAILED);
         assertThat(statusCaptor.getAllValues().get(1).getStatusReason()).contains("137");
+    }
+
+    @Test
+    void startRun_whenExitCodeMissing_updatesFailed() {
+        when(metricCollectorAdapter.startCollection(BENCHMARK_ID, RUN_ID)).thenReturn(true);
+        when(containerPort.startContainer(any(ContainerStartRequest.class))).thenReturn("k6-id");
+        when(containerPort.isContainerRunning("k6-id")).thenReturn(false);
+        when(containerPort.getContainerExitCode("k6-id")).thenReturn(null);
+
+        service.startRun(BENCHMARK_ID, RUN_ID, "script");
+
+        var statusCaptor = ArgumentCaptor.forClass(BenchmarkRunStatusUpdateDTO.class);
+        verify(viplevApiPort, org.mockito.Mockito.times(2)).updateRunStatus(any(), any(), statusCaptor.capture());
+        assertThat(statusCaptor.getAllValues().get(0).getStatus()).isEqualTo(BenchmarkRunStatusUpdateDTO.StatusEnum.STARTED);
+        assertThat(statusCaptor.getAllValues().get(1).getStatus()).isEqualTo(BenchmarkRunStatusUpdateDTO.StatusEnum.FAILED);
+        assertThat(statusCaptor.getAllValues().get(1).getStatusReason()).contains("no exit code");
     }
 
     @Test

--- a/src/test/resources/application-test.properties
+++ b/src/test/resources/application-test.properties
@@ -4,3 +4,5 @@ spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
 viplev.url=http://localhost:9999
 viplev.token=test-token
 viplev.environment-id=00000000-0000-0000-0000-000000000001
+agent.k6-image=grafana/k6:0.53.0
+agent.k6-network=viplev_agent


### PR DESCRIPTION
## Summary
- add a dedicated `MessagePollingAdapter` that polls VIPLEV on a dynamic idle/active interval and processes only the first message in the returned list
- introduce benchmark run orchestration via `BenchmarkExecutionUseCase` + `BenchmarkExecutionServiceImpl`, including run context tracking, START/STOP handling, and K6 container lifecycle monitoring
- extend outbound VIPLEV integration with benchmark lookup (`getBenchmark`) and wire scheduling/configuration needed for message-driven benchmark execution

## Test
- `./gradlew test`

## Issue
Closes #9