### PR TITLE
fix(metrics): stabilize scraper ingestion and isolate run buffer

### DIFF
--- a/src/main/java/dk/viplev/agent/adapter/outbound/container/docker/ExporterLifecycleManager.java
+++ b/src/main/java/dk/viplev/agent/adapter/outbound/container/docker/ExporterLifecycleManager.java
@@ -19,6 +19,7 @@ import com.github.dockerjava.api.model.ServiceModeConfig;
 import com.github.dockerjava.api.model.ServiceSpec;
 import com.github.dockerjava.api.model.TaskSpec;
 import com.github.dockerjava.api.model.Volume;
+import dk.viplev.agent.config.ExporterConstants;
 import dk.viplev.agent.domain.exception.ContainerRuntimeException;
 import jakarta.annotation.PreDestroy;
 import lombok.extern.slf4j.Slf4j;
@@ -39,21 +40,27 @@ import java.util.List;
 @Profile("docker")
 public class ExporterLifecycleManager {
 
-    static final String NETWORK_NAME = "viplev_agent";
-    static final String CADVISOR_CONTAINER_NAME = "viplev-cadvisor";
-    static final String NODE_EXPORTER_CONTAINER_NAME = "viplev-node-exporter";
+    static final String NETWORK_NAME = ExporterConstants.NETWORK_NAME;
+    static final String CADVISOR_CONTAINER_NAME = ExporterConstants.CADVISOR_CONTAINER_NAME;
+    static final String NODE_EXPORTER_CONTAINER_NAME = ExporterConstants.NODE_EXPORTER_CONTAINER_NAME;
 
     private final DockerClient dockerClient;
     private final String cadvisorImage;
     private final String nodeExporterImage;
+    private final String cadvisorContainerName;
+    private final String nodeExporterContainerName;
 
     public ExporterLifecycleManager(
             DockerClient dockerClient,
             @Value("${agent.cadvisor-image}") String cadvisorImage,
-            @Value("${agent.node-exporter-image}") String nodeExporterImage) {
+            @Value("${agent.node-exporter-image}") String nodeExporterImage,
+            @Value("${agent.cadvisor-container-name:" + CADVISOR_CONTAINER_NAME + "}") String cadvisorContainerName,
+            @Value("${agent.node-exporter-container-name:" + NODE_EXPORTER_CONTAINER_NAME + "}") String nodeExporterContainerName) {
         this.dockerClient = dockerClient;
         this.cadvisorImage = cadvisorImage;
         this.nodeExporterImage = nodeExporterImage;
+        this.cadvisorContainerName = cadvisorContainerName;
+        this.nodeExporterContainerName = nodeExporterContainerName;
     }
 
     @EventListener(ApplicationReadyEvent.class)
@@ -63,17 +70,17 @@ public class ExporterLifecycleManager {
 
         if (swarm) {
             connectAgentToNetwork(networkId);
-            startSwarmServiceIfAbsent(CADVISOR_CONTAINER_NAME, cadvisorImage,
+            startSwarmServiceIfAbsent(cadvisorContainerName, cadvisorImage,
                     buildCadvisorMounts(), List.of(), networkId);
-            startSwarmServiceIfAbsent(NODE_EXPORTER_CONTAINER_NAME, nodeExporterImage,
+            startSwarmServiceIfAbsent(nodeExporterContainerName, nodeExporterImage,
                     buildNodeExporterMounts(),
                     List.of("--path.procfs=/host/proc", "--path.sysfs=/host/sys", "--path.rootfs=/rootfs"), networkId);
         } else {
             connectAgentToNetwork(networkId);
             pullImageIfAbsent(cadvisorImage);
-            startContainerIfAbsent(CADVISOR_CONTAINER_NAME, cadvisorImage, buildCadvisorHostConfig(), List.of());
+            startContainerIfAbsent(cadvisorContainerName, cadvisorImage, buildCadvisorHostConfig(), List.of());
             pullImageIfAbsent(nodeExporterImage);
-            startContainerIfAbsent(NODE_EXPORTER_CONTAINER_NAME, nodeExporterImage, buildNodeExporterHostConfig(),
+            startContainerIfAbsent(nodeExporterContainerName, nodeExporterImage, buildNodeExporterHostConfig(),
                     List.of("--path.procfs=/host/proc", "--path.sysfs=/host/sys", "--path.rootfs=/rootfs"));
         }
     }
@@ -81,11 +88,11 @@ public class ExporterLifecycleManager {
     @PreDestroy
     public void stop() {
         if (isSwarmActive()) {
-            removeSwarmService(CADVISOR_CONTAINER_NAME);
-            removeSwarmService(NODE_EXPORTER_CONTAINER_NAME);
+            removeSwarmService(cadvisorContainerName);
+            removeSwarmService(nodeExporterContainerName);
         } else {
-            removeContainer(CADVISOR_CONTAINER_NAME);
-            removeContainer(NODE_EXPORTER_CONTAINER_NAME);
+            removeContainer(cadvisorContainerName);
+            removeContainer(nodeExporterContainerName);
         }
         removeNetwork(NETWORK_NAME);
     }

--- a/src/main/java/dk/viplev/agent/adapter/outbound/metrics/cadvisor/CadvisorAdapter.java
+++ b/src/main/java/dk/viplev/agent/adapter/outbound/metrics/cadvisor/CadvisorAdapter.java
@@ -12,6 +12,8 @@ import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 
 import java.time.Duration;
+import java.math.BigInteger;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -21,8 +23,9 @@ import java.util.stream.Collectors;
 @Profile("docker")
 public class CadvisorAdapter implements CadvisorPort {
 
-    private static final String STATS_PATH = "/api/v2.0/stats?type=docker&count=2";
+    private static final String STATS_PATH = "/api/v1.3/docker";
     private static final String DOCKER_PATH_PREFIX = "/docker/";
+    private static final BigInteger UNSPECIFIED_CGROUP_MEMORY_LIMIT = BigInteger.valueOf(Long.MAX_VALUE);
 
     private final RestTemplate restTemplate;
 
@@ -38,11 +41,40 @@ public class CadvisorAdapter implements CadvisorPort {
         }
 
         return response.entrySet().stream()
-                .filter(e -> e.getKey().startsWith(DOCKER_PATH_PREFIX))
+                .filter(e -> isDockerContainerEntry(e.getKey(), e.getValue()))
                 .collect(Collectors.toMap(
-                        e -> e.getKey().substring(DOCKER_PATH_PREFIX.length()),
+                        e -> resolveContainerId(e.getKey(), e.getValue()),
                         e -> toContainerStats(e.getValue())
                 ));
+    }
+
+    private boolean isDockerContainerEntry(String key, CadvisorContainerInfo info) {
+        String id = resolveContainerId(key, info);
+        return id != null && !id.isBlank();
+    }
+
+    private String resolveContainerId(String key, CadvisorContainerInfo info) {
+        if (info != null && isContainerId(info.id())) {
+            return info.id();
+        }
+        if (info != null && info.aliases() != null) {
+            for (String alias : info.aliases()) {
+                if (isContainerId(alias)) {
+                    return alias;
+                }
+            }
+        }
+        if (key != null && key.startsWith(DOCKER_PATH_PREFIX)) {
+            String candidate = key.substring(DOCKER_PATH_PREFIX.length());
+            if (isContainerId(candidate)) {
+                return candidate;
+            }
+        }
+        return null;
+    }
+
+    private boolean isContainerId(String value) {
+        return value != null && value.matches("[a-f0-9]{12,64}");
     }
 
     private Map<String, CadvisorContainerInfo> fetchStats(String baseUrl) {
@@ -52,7 +84,7 @@ public class CadvisorAdapter implements CadvisorPort {
                     url,
                     HttpMethod.GET,
                     null,
-                    new ParameterizedTypeReference<Map<String, CadvisorContainerInfo>>() {}
+                    new ParameterizedTypeReference<LinkedHashMap<String, CadvisorContainerInfo>>() {}
             ).getBody();
         } catch (RestClientException e) {
             throw new ContainerRuntimeException(
@@ -107,7 +139,14 @@ public class CadvisorAdapter implements CadvisorPort {
         if (info.spec() == null || info.spec().memory() == null) {
             return 0L;
         }
-        return info.spec().memory().limit();
+        BigInteger limit = info.spec().memory().limit();
+        if (limit == null || limit.signum() <= 0) {
+            return 0L;
+        }
+        if (limit.compareTo(UNSPECIFIED_CGROUP_MEMORY_LIMIT) >= 0) {
+            return 0L;
+        }
+        return limit.longValue();
     }
 
     private long sumNetworkBytes(CadvisorContainerInfo.CadvisorStat stat, boolean rx) {

--- a/src/main/java/dk/viplev/agent/adapter/outbound/metrics/cadvisor/CadvisorAdapter.java
+++ b/src/main/java/dk/viplev/agent/adapter/outbound/metrics/cadvisor/CadvisorAdapter.java
@@ -16,6 +16,8 @@ import java.math.BigInteger;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 @Slf4j
@@ -26,6 +28,7 @@ public class CadvisorAdapter implements CadvisorPort {
     private static final String STATS_PATH = "/api/v1.3/docker";
     private static final String DOCKER_PATH_PREFIX = "/docker/";
     private static final BigInteger UNSPECIFIED_CGROUP_MEMORY_LIMIT = BigInteger.valueOf(Long.MAX_VALUE);
+    private static final Pattern CONTAINER_ID_PATTERN = Pattern.compile("^[a-f0-9]{12,64}$");
 
     private final RestTemplate restTemplate;
 
@@ -41,16 +44,22 @@ public class CadvisorAdapter implements CadvisorPort {
         }
 
         return response.entrySet().stream()
-                .filter(e -> isDockerContainerEntry(e.getKey(), e.getValue()))
+                .map(e -> toResolvedEntry(e.getKey(), e.getValue()))
+                .filter(Objects::nonNull)
                 .collect(Collectors.toMap(
-                        e -> resolveContainerId(e.getKey(), e.getValue()),
-                        e -> toContainerStats(e.getValue())
+                        ResolvedContainerEntry::containerId,
+                        e -> toContainerStats(e.info()),
+                        (existing, ignored) -> existing,
+                        LinkedHashMap::new
                 ));
     }
 
-    private boolean isDockerContainerEntry(String key, CadvisorContainerInfo info) {
+    private ResolvedContainerEntry toResolvedEntry(String key, CadvisorContainerInfo info) {
         String id = resolveContainerId(key, info);
-        return id != null && !id.isBlank();
+        if (id == null || id.isBlank()) {
+            return null;
+        }
+        return new ResolvedContainerEntry(id, info);
     }
 
     private String resolveContainerId(String key, CadvisorContainerInfo info) {
@@ -74,7 +83,10 @@ public class CadvisorAdapter implements CadvisorPort {
     }
 
     private boolean isContainerId(String value) {
-        return value != null && value.matches("[a-f0-9]{12,64}");
+        return value != null && CONTAINER_ID_PATTERN.matcher(value).matches();
+    }
+
+    private record ResolvedContainerEntry(String containerId, CadvisorContainerInfo info) {
     }
 
     private Map<String, CadvisorContainerInfo> fetchStats(String baseUrl) {

--- a/src/main/java/dk/viplev/agent/adapter/outbound/metrics/cadvisor/CadvisorContainerInfo.java
+++ b/src/main/java/dk/viplev/agent/adapter/outbound/metrics/cadvisor/CadvisorContainerInfo.java
@@ -4,11 +4,14 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.time.Instant;
+import java.math.BigInteger;
 import java.util.List;
 import java.util.Map;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 record CadvisorContainerInfo(
+        @JsonProperty("id") String id,
+        @JsonProperty("aliases") List<String> aliases,
         @JsonProperty("spec") CadvisorSpec spec,
         @JsonProperty("stats") List<CadvisorStat> stats
 ) {
@@ -20,7 +23,7 @@ record CadvisorContainerInfo(
 
     @JsonIgnoreProperties(ignoreUnknown = true)
     record CadvisorMemorySpec(
-            @JsonProperty("limit") long limit
+            @JsonProperty("limit") BigInteger limit
     ) {}
 
     @JsonIgnoreProperties(ignoreUnknown = true)

--- a/src/main/java/dk/viplev/agent/config/ExporterConstants.java
+++ b/src/main/java/dk/viplev/agent/config/ExporterConstants.java
@@ -1,0 +1,11 @@
+package dk.viplev.agent.config;
+
+public final class ExporterConstants {
+
+    public static final String NETWORK_NAME = "viplev_agent";
+    public static final String CADVISOR_CONTAINER_NAME = "viplev-cadvisor";
+    public static final String NODE_EXPORTER_CONTAINER_NAME = "viplev-node-exporter";
+
+    private ExporterConstants() {
+    }
+}

--- a/src/main/java/dk/viplev/agent/domain/services/MetricCollectionServiceImpl.java
+++ b/src/main/java/dk/viplev/agent/domain/services/MetricCollectionServiceImpl.java
@@ -22,10 +22,13 @@ import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -38,6 +41,8 @@ public class MetricCollectionServiceImpl implements MetricCollectionUseCase {
 
     private static final Logger log = LoggerFactory.getLogger(MetricCollectionServiceImpl.class);
     private static final AtomicInteger THREAD_COUNTER = new AtomicInteger(0);
+    private static final String LOCAL_NODE_EXPORTER_HOST = "viplev-node-exporter";
+    private static final String LOCAL_CADVISOR_HOST = "viplev-cadvisor";
 
     private final NodeExporterPort nodeExporterPort;
     private final CadvisorPort cadvisorPort;
@@ -50,11 +55,38 @@ public class MetricCollectionServiceImpl implements MetricCollectionUseCase {
     private final int cadvisorPortNumber;
     @Nullable
     private final ScheduledExecutorService executorOverride;
+    private final Map<ScraperKey, ScraperHealth> scraperHealthStates = new ConcurrentHashMap<>();
+    private final Object metricsDbLock = new Object();
 
     private volatile UUID benchmarkId;
     private volatile UUID runId;
     private volatile ScheduledExecutorService executor;
     private volatile String localMachineId;
+
+    enum ScraperType {
+        NODE_EXPORTER("node_exporter"),
+        CADVISOR("cadvisor");
+
+        private final String logName;
+
+        ScraperType(String logName) {
+            this.logName = logName;
+        }
+    }
+
+    enum ScraperHealth {
+        HEALTHY,
+        DEGRADED
+    }
+
+    enum ScraperTransition {
+        NONE,
+        DEGRADED,
+        RECOVERED
+    }
+
+    record ScraperKey(String machineId, ScraperType scraperType) {
+    }
 
     public MetricCollectionServiceImpl(NodeExporterPort nodeExporterPort,
                                        CadvisorPort cadvisorPort,
@@ -85,6 +117,8 @@ public class MetricCollectionServiceImpl implements MetricCollectionUseCase {
                     this.benchmarkId, this.runId);
             return false;
         }
+
+        clearBufferedMetrics("starting new collection");
 
         this.benchmarkId = benchmarkId;
         this.runId = runId;
@@ -125,6 +159,7 @@ public class MetricCollectionServiceImpl implements MetricCollectionUseCase {
         executor = null;
 
         flushMetrics();
+        clearBufferedMetrics("stopping collection");
 
         log.info("Metric collection stopped for benchmark={} run={}", benchmarkId, runId);
 
@@ -136,12 +171,16 @@ public class MetricCollectionServiceImpl implements MetricCollectionUseCase {
     void collectMetrics() {
         try {
             var nodes = nodeDiscoveryPort.discoverNodes();
+            pruneScraperStates(nodes);
 
             String localId = getLocalMachineId();
 
             for (var node : nodes) {
-                String nodeExporterUrl = "http://" + node.ipAddress() + ":" + nodeExporterPortNumber;
-                String cadvisorUrl = "http://" + node.ipAddress() + ":" + cadvisorPortNumber;
+                boolean isLocalNode = node.machineId().equals(localId);
+                String nodeExporterHost = isLocalNode ? LOCAL_NODE_EXPORTER_HOST : node.ipAddress();
+                String cadvisorHost = isLocalNode ? LOCAL_CADVISOR_HOST : node.ipAddress();
+                String nodeExporterUrl = "http://" + nodeExporterHost + ":" + nodeExporterPortNumber;
+                String cadvisorUrl = "http://" + cadvisorHost + ":" + cadvisorPortNumber;
                 try {
                     var hostStats = nodeExporterPort.scrapeHostStats(nodeExporterUrl);
                     var hostMetric = ResourceMetric.builder()
@@ -157,16 +196,19 @@ public class MetricCollectionServiceImpl implements MetricCollectionUseCase {
                             .blockInBytes((double) hostStats.blockInBytes())
                             .blockOutBytes((double) hostStats.blockOutBytes())
                             .build();
-                    resourceMetricRepository.save(hostMetric);
+                    synchronized (metricsDbLock) {
+                        resourceMetricRepository.save(hostMetric);
+                    }
+                    logScraperSuccess(node.machineId(), ScraperType.NODE_EXPORTER);
                 } catch (Exception e) {
-                    log.warn("Failed to collect host stats for node={}", node.machineId(), e);
+                    logScraperFailure(node.machineId(), ScraperType.NODE_EXPORTER, e);
                 }
 
                 try {
                     var containerStatsMap = cadvisorPort.scrapeAllContainerStats(cadvisorUrl);
 
                     Map<String, String> idToName;
-                    if (node.machineId().equals(localId)) {
+                    if (isLocalNode) {
                         var containers = containerPort.listContainers();
                         idToName = containers.stream()
                                 .collect(Collectors.toMap(c -> c.id(), c -> c.name()));
@@ -192,10 +234,13 @@ public class MetricCollectionServiceImpl implements MetricCollectionUseCase {
                                 .blockInBytes((double) stats.blockInBytes())
                                 .blockOutBytes((double) stats.blockOutBytes())
                                 .build();
-                        resourceMetricRepository.save(containerMetric);
+                        synchronized (metricsDbLock) {
+                            resourceMetricRepository.save(containerMetric);
+                        }
                     }
+                    logScraperSuccess(node.machineId(), ScraperType.CADVISOR);
                 } catch (Exception e) {
-                    log.warn("Failed to collect container stats for node={}", node.machineId(), e);
+                    logScraperFailure(node.machineId(), ScraperType.CADVISOR, e);
                 }
             }
         } catch (Exception e) {
@@ -205,7 +250,10 @@ public class MetricCollectionServiceImpl implements MetricCollectionUseCase {
 
     void flushMetrics() {
         try {
-            var unflushed = resourceMetricRepository.findByFlushedFalseOrderByCollectedAtAsc();
+            List<ResourceMetric> unflushed;
+            synchronized (metricsDbLock) {
+                unflushed = resourceMetricRepository.findByFlushedFalseOrderByCollectedAtAsc();
+            }
             if (unflushed.isEmpty()) {
                 return;
             }
@@ -220,7 +268,9 @@ public class MetricCollectionServiceImpl implements MetricCollectionUseCase {
             boolean hasNullMachineId = unflushed.stream().anyMatch(m -> m.getMachineId() == null);
             if (hasNullMachineId) {
                 log.warn("Deleting legacy resource metrics with null machineId — these cannot be flushed");
-                resourceMetricRepository.deleteByMachineIdIsNull();
+                synchronized (metricsDbLock) {
+                    resourceMetricRepository.deleteByMachineIdIsNull();
+                }
             }
 
             unflushed = unflushed.stream()
@@ -288,11 +338,13 @@ public class MetricCollectionServiceImpl implements MetricCollectionUseCase {
             }
 
             var dto = new MetricResourceDTO().hosts(nodeDTOs);
+            List<UUID> flushedIds = unflushed.stream().map(ResourceMetric::getId).toList();
 
             try {
                 viplevApiPort.sendResourceMetrics(benchmarkId, runId, dto);
-                unflushed.forEach(m -> m.setFlushed(true));
-                resourceMetricRepository.saveAll(unflushed);
+                synchronized (metricsDbLock) {
+                    resourceMetricRepository.deleteAllByIdInBatch(flushedIds);
+                }
                 log.debug("Flushed {} metrics to VIPLEV", unflushed.size());
             } catch (Exception e) {
                 log.warn("Failed to send resource metrics to VIPLEV; will retry on next flush", e);
@@ -307,5 +359,68 @@ public class MetricCollectionServiceImpl implements MetricCollectionUseCase {
             localMachineId = nodeDiscoveryPort.getLocalNodeId();
         }
         return localMachineId;
+    }
+
+    ScraperTransition markScraperFailure(String machineId, ScraperType scraperType) {
+        ScraperKey key = new ScraperKey(machineId, scraperType);
+        ScraperHealth previous = scraperHealthStates.put(key, ScraperHealth.DEGRADED);
+        if (previous == ScraperHealth.DEGRADED) {
+            return ScraperTransition.NONE;
+        }
+        return ScraperTransition.DEGRADED;
+    }
+
+    ScraperTransition markScraperSuccess(String machineId, ScraperType scraperType) {
+        ScraperKey key = new ScraperKey(machineId, scraperType);
+        ScraperHealth previous = scraperHealthStates.put(key, ScraperHealth.HEALTHY);
+        if (previous == ScraperHealth.DEGRADED) {
+            return ScraperTransition.RECOVERED;
+        }
+        return ScraperTransition.NONE;
+    }
+
+    void pruneScraperStates(List<dk.viplev.agent.domain.model.NodeInfo> nodes) {
+        Set<String> activeMachineIds = new HashSet<>();
+        for (var node : nodes) {
+            activeMachineIds.add(node.machineId());
+        }
+        scraperHealthStates.keySet().removeIf(key -> !activeMachineIds.contains(key.machineId()));
+    }
+
+    @Nullable
+    ScraperHealth getScraperHealth(String machineId, ScraperType scraperType) {
+        return scraperHealthStates.get(new ScraperKey(machineId, scraperType));
+    }
+
+    private void logScraperFailure(String machineId, ScraperType scraperType, Exception e) {
+        ScraperTransition transition = markScraperFailure(machineId, scraperType);
+        String errorMessage = e.getMessage();
+        if (transition == ScraperTransition.DEGRADED) {
+            log.warn("Metric scraper {} degraded for node={}: {}", scraperType.logName, machineId, errorMessage);
+            log.debug("Metric scraper {} degraded stacktrace for node={}", scraperType.logName, machineId, e);
+            return;
+        }
+        log.debug("Metric scraper {} still degraded for node={}: {}",
+                scraperType.logName,
+                machineId,
+                errorMessage);
+    }
+
+    private void logScraperSuccess(String machineId, ScraperType scraperType) {
+        ScraperTransition transition = markScraperSuccess(machineId, scraperType);
+        if (transition == ScraperTransition.RECOVERED) {
+            log.info("Metric scraper {} recovered for node={}", scraperType.logName, machineId);
+        }
+    }
+
+    private void clearBufferedMetrics(String reason) {
+        synchronized (metricsDbLock) {
+            long rowCount = resourceMetricRepository.count();
+            if (rowCount == 0) {
+                return;
+            }
+            resourceMetricRepository.deleteAllInBatch();
+            log.info("Cleared {} buffered resource metrics while {}", rowCount, reason);
+        }
     }
 }

--- a/src/main/java/dk/viplev/agent/domain/services/MetricCollectionServiceImpl.java
+++ b/src/main/java/dk/viplev/agent/domain/services/MetricCollectionServiceImpl.java
@@ -32,6 +32,7 @@ import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
@@ -54,6 +55,7 @@ public class MetricCollectionServiceImpl implements MetricCollectionUseCase {
     private final int cadvisorPortNumber;
     private final String localNodeExporterHost;
     private final String localCadvisorHost;
+    private final boolean clearBufferedMetricsOnStart;
     @Nullable
     private final ScheduledExecutorService executorOverride;
     private final Map<ScraperKey, ScraperHealth> scraperHealthStates = new ConcurrentHashMap<>();
@@ -62,7 +64,12 @@ public class MetricCollectionServiceImpl implements MetricCollectionUseCase {
     private volatile UUID benchmarkId;
     private volatile UUID runId;
     private volatile ScheduledExecutorService executor;
+    @Nullable
+    private volatile ScheduledFuture<?> collectTask;
+    @Nullable
+    private volatile ScheduledFuture<?> flushTask;
     private volatile String localMachineId;
+    private volatile boolean acceptingCollection = true;
 
     enum ScraperType {
         NODE_EXPORTER("node_exporter"),
@@ -109,6 +116,7 @@ public class MetricCollectionServiceImpl implements MetricCollectionUseCase {
                                        @Value("${agent.cadvisor-port}") int cadvisorPortNumber,
                                        @Value("${agent.node-exporter-container-name:" + ExporterConstants.NODE_EXPORTER_CONTAINER_NAME + "}") String localNodeExporterHost,
                                        @Value("${agent.cadvisor-container-name:" + ExporterConstants.CADVISOR_CONTAINER_NAME + "}") String localCadvisorHost,
+                                       @Value("${agent.clear-buffered-metrics-on-start:true}") boolean clearBufferedMetricsOnStart,
                                        @Nullable ScheduledExecutorService executorOverride) {
         this.nodeExporterPort = nodeExporterPort;
         this.cadvisorPort = cadvisorPort;
@@ -121,6 +129,7 @@ public class MetricCollectionServiceImpl implements MetricCollectionUseCase {
         this.cadvisorPortNumber = cadvisorPortNumber;
         this.localNodeExporterHost = localNodeExporterHost;
         this.localCadvisorHost = localCadvisorHost;
+        this.clearBufferedMetricsOnStart = clearBufferedMetricsOnStart;
         this.executorOverride = executorOverride;
     }
 
@@ -132,7 +141,11 @@ public class MetricCollectionServiceImpl implements MetricCollectionUseCase {
             return false;
         }
 
-        clearBufferedMetrics("starting new collection");
+        if (clearBufferedMetricsOnStart) {
+            clearBufferedMetrics("starting new collection");
+        } else {
+            log.info("Preserving buffered resource metrics on start because agent.clear-buffered-metrics-on-start=false");
+        }
 
         this.benchmarkId = benchmarkId;
         this.runId = runId;
@@ -147,8 +160,9 @@ public class MetricCollectionServiceImpl implements MetricCollectionUseCase {
             });
         }
 
-        executor.scheduleAtFixedRate(this::collectMetrics, 0, 1, TimeUnit.SECONDS);
-        executor.scheduleAtFixedRate(this::flushMetrics, 5, 5, TimeUnit.SECONDS);
+        acceptingCollection = true;
+        collectTask = executor.scheduleAtFixedRate(this::collectMetrics, 0, 1, TimeUnit.SECONDS);
+        flushTask = executor.scheduleAtFixedRate(this::flushMetrics, 5, 5, TimeUnit.SECONDS);
 
         log.info("Metric collection started for benchmark={} run={}", benchmarkId, runId);
         return true;
@@ -161,15 +175,29 @@ public class MetricCollectionServiceImpl implements MetricCollectionUseCase {
             return false;
         }
 
+        acceptingCollection = false;
+        cancelScheduledTask(collectTask);
+        cancelScheduledTask(flushTask);
+        collectTask = null;
+        flushTask = null;
+
         executor.shutdown();
+        boolean terminated = false;
         try {
-            if (!executor.awaitTermination(5, TimeUnit.SECONDS)) {
+            terminated = executor.awaitTermination(5, TimeUnit.SECONDS);
+            if (!terminated) {
                 executor.shutdownNow();
+                terminated = executor.awaitTermination(5, TimeUnit.SECONDS);
             }
         } catch (InterruptedException e) {
             executor.shutdownNow();
             Thread.currentThread().interrupt();
         }
+
+        if (!terminated) {
+            log.warn("Metric collection executor did not terminate cleanly before final flush/cleanup");
+        }
+
         executor = null;
 
         FlushResult flushResult = flushMetrics(false);
@@ -186,13 +214,23 @@ public class MetricCollectionServiceImpl implements MetricCollectionUseCase {
     }
 
     void collectMetrics() {
+        if (!acceptingCollection || Thread.currentThread().isInterrupted()) {
+            return;
+        }
+
         try {
             var nodes = nodeDiscoveryPort.discoverNodes();
+            if (!acceptingCollection || Thread.currentThread().isInterrupted()) {
+                return;
+            }
             pruneScraperStates(nodes);
 
             String localId = getLocalMachineId();
 
             for (var node : nodes) {
+                if (!acceptingCollection || Thread.currentThread().isInterrupted()) {
+                    return;
+                }
                 boolean isLocalNode = node.machineId().equals(localId);
                 String nodeExporterHost = isLocalNode ? localNodeExporterHost : node.ipAddress();
                 String cadvisorHost = isLocalNode ? localCadvisorHost : node.ipAddress();
@@ -213,8 +251,10 @@ public class MetricCollectionServiceImpl implements MetricCollectionUseCase {
                             .blockInBytes((double) hostStats.blockInBytes())
                             .blockOutBytes((double) hostStats.blockOutBytes())
                             .build();
-                    synchronized (metricsDbLock) {
-                        resourceMetricRepository.save(hostMetric);
+                    if (acceptingCollection && !Thread.currentThread().isInterrupted()) {
+                        synchronized (metricsDbLock) {
+                            resourceMetricRepository.save(hostMetric);
+                        }
                     }
                     logScraperSuccess(node.machineId(), ScraperType.NODE_EXPORTER);
                 } catch (Exception e) {
@@ -234,6 +274,9 @@ public class MetricCollectionServiceImpl implements MetricCollectionUseCase {
                     }
 
                     for (var entry : containerStatsMap.entrySet()) {
+                        if (!acceptingCollection || Thread.currentThread().isInterrupted()) {
+                            return;
+                        }
                         var containerId = entry.getKey();
                         var stats = entry.getValue();
                         var containerName = idToName.getOrDefault(containerId, containerId);
@@ -251,8 +294,10 @@ public class MetricCollectionServiceImpl implements MetricCollectionUseCase {
                                 .blockInBytes((double) stats.blockInBytes())
                                 .blockOutBytes((double) stats.blockOutBytes())
                                 .build();
-                        synchronized (metricsDbLock) {
-                            resourceMetricRepository.save(containerMetric);
+                        if (acceptingCollection && !Thread.currentThread().isInterrupted()) {
+                            synchronized (metricsDbLock) {
+                                resourceMetricRepository.save(containerMetric);
+                            }
                         }
                     }
                     logScraperSuccess(node.machineId(), ScraperType.CADVISOR);
@@ -270,6 +315,10 @@ public class MetricCollectionServiceImpl implements MetricCollectionUseCase {
     }
 
     private FlushResult flushMetrics(boolean allowRetryLogging) {
+        if (!acceptingCollection && allowRetryLogging) {
+            return new FlushResult(FlushStatus.SKIPPED, 0);
+        }
+
         try {
             List<ResourceMetric> unflushed;
             synchronized (metricsDbLock) {
@@ -450,5 +499,12 @@ public class MetricCollectionServiceImpl implements MetricCollectionUseCase {
             resourceMetricRepository.deleteAllInBatch();
             log.info("Cleared {} buffered resource metrics while {}", rowCount, reason);
         }
+    }
+
+    private void cancelScheduledTask(@Nullable ScheduledFuture<?> task) {
+        if (task == null) {
+            return;
+        }
+        task.cancel(true);
     }
 }

--- a/src/main/java/dk/viplev/agent/domain/services/MetricCollectionServiceImpl.java
+++ b/src/main/java/dk/viplev/agent/domain/services/MetricCollectionServiceImpl.java
@@ -3,6 +3,7 @@ package dk.viplev.agent.domain.services;
 import dk.viplev.agent.domain.mapper.ResourceMetricMapper;
 import dk.viplev.agent.domain.model.ResourceMetric;
 import dk.viplev.agent.domain.model.TargetType;
+import dk.viplev.agent.config.ExporterConstants;
 import dk.viplev.agent.generated.model.MetricResourceDTO;
 import dk.viplev.agent.generated.model.MetricResourceNodeDTO;
 import dk.viplev.agent.generated.model.MetricResourceServiceDTO;
@@ -41,8 +42,6 @@ public class MetricCollectionServiceImpl implements MetricCollectionUseCase {
 
     private static final Logger log = LoggerFactory.getLogger(MetricCollectionServiceImpl.class);
     private static final AtomicInteger THREAD_COUNTER = new AtomicInteger(0);
-    private static final String LOCAL_NODE_EXPORTER_HOST = "viplev-node-exporter";
-    private static final String LOCAL_CADVISOR_HOST = "viplev-cadvisor";
 
     private final NodeExporterPort nodeExporterPort;
     private final CadvisorPort cadvisorPort;
@@ -53,6 +52,8 @@ public class MetricCollectionServiceImpl implements MetricCollectionUseCase {
     private final ResourceMetricMapper resourceMetricMapper;
     private final int nodeExporterPortNumber;
     private final int cadvisorPortNumber;
+    private final String localNodeExporterHost;
+    private final String localCadvisorHost;
     @Nullable
     private final ScheduledExecutorService executorOverride;
     private final Map<ScraperKey, ScraperHealth> scraperHealthStates = new ConcurrentHashMap<>();
@@ -85,6 +86,15 @@ public class MetricCollectionServiceImpl implements MetricCollectionUseCase {
         RECOVERED
     }
 
+    enum FlushStatus {
+        SENT,
+        FAILED,
+        SKIPPED
+    }
+
+    record FlushResult(FlushStatus status, int metricCount) {
+    }
+
     record ScraperKey(String machineId, ScraperType scraperType) {
     }
 
@@ -97,6 +107,8 @@ public class MetricCollectionServiceImpl implements MetricCollectionUseCase {
                                        ResourceMetricMapper resourceMetricMapper,
                                        @Value("${agent.node-exporter-port}") int nodeExporterPortNumber,
                                        @Value("${agent.cadvisor-port}") int cadvisorPortNumber,
+                                       @Value("${agent.node-exporter-container-name:" + ExporterConstants.NODE_EXPORTER_CONTAINER_NAME + "}") String localNodeExporterHost,
+                                       @Value("${agent.cadvisor-container-name:" + ExporterConstants.CADVISOR_CONTAINER_NAME + "}") String localCadvisorHost,
                                        @Nullable ScheduledExecutorService executorOverride) {
         this.nodeExporterPort = nodeExporterPort;
         this.cadvisorPort = cadvisorPort;
@@ -107,6 +119,8 @@ public class MetricCollectionServiceImpl implements MetricCollectionUseCase {
         this.resourceMetricMapper = resourceMetricMapper;
         this.nodeExporterPortNumber = nodeExporterPortNumber;
         this.cadvisorPortNumber = cadvisorPortNumber;
+        this.localNodeExporterHost = localNodeExporterHost;
+        this.localCadvisorHost = localCadvisorHost;
         this.executorOverride = executorOverride;
     }
 
@@ -158,7 +172,10 @@ public class MetricCollectionServiceImpl implements MetricCollectionUseCase {
         }
         executor = null;
 
-        flushMetrics();
+        FlushResult flushResult = flushMetrics(false);
+        if (flushResult.status == FlushStatus.FAILED && flushResult.metricCount > 0) {
+            log.warn("Discarding {} unsent resource metrics while stopping collection", flushResult.metricCount);
+        }
         clearBufferedMetrics("stopping collection");
 
         log.info("Metric collection stopped for benchmark={} run={}", benchmarkId, runId);
@@ -177,8 +194,8 @@ public class MetricCollectionServiceImpl implements MetricCollectionUseCase {
 
             for (var node : nodes) {
                 boolean isLocalNode = node.machineId().equals(localId);
-                String nodeExporterHost = isLocalNode ? LOCAL_NODE_EXPORTER_HOST : node.ipAddress();
-                String cadvisorHost = isLocalNode ? LOCAL_CADVISOR_HOST : node.ipAddress();
+                String nodeExporterHost = isLocalNode ? localNodeExporterHost : node.ipAddress();
+                String cadvisorHost = isLocalNode ? localCadvisorHost : node.ipAddress();
                 String nodeExporterUrl = "http://" + nodeExporterHost + ":" + nodeExporterPortNumber;
                 String cadvisorUrl = "http://" + cadvisorHost + ":" + cadvisorPortNumber;
                 try {
@@ -249,19 +266,23 @@ public class MetricCollectionServiceImpl implements MetricCollectionUseCase {
     }
 
     void flushMetrics() {
+        flushMetrics(true);
+    }
+
+    private FlushResult flushMetrics(boolean allowRetryLogging) {
         try {
             List<ResourceMetric> unflushed;
             synchronized (metricsDbLock) {
                 unflushed = resourceMetricRepository.findByFlushedFalseOrderByCollectedAtAsc();
             }
             if (unflushed.isEmpty()) {
-                return;
+                return new FlushResult(FlushStatus.SKIPPED, 0);
             }
 
             if (benchmarkId == null || runId == null) {
                 log.warn("flushMetrics called before startCollection (benchmarkId={}, runId={}); skipping flush",
                         benchmarkId, runId);
-                return;
+                return new FlushResult(FlushStatus.SKIPPED, unflushed.size());
             }
 
             // Filter out legacy metrics with null machineId and delete them
@@ -277,7 +298,7 @@ public class MetricCollectionServiceImpl implements MetricCollectionUseCase {
                     .filter(m -> m.getMachineId() != null)
                     .toList();
             if (unflushed.isEmpty()) {
-                return;
+                return new FlushResult(FlushStatus.SKIPPED, 0);
             }
 
             // Group host metrics by machineId
@@ -334,7 +355,7 @@ public class MetricCollectionServiceImpl implements MetricCollectionUseCase {
 
             if (nodeDTOs.isEmpty()) {
                 log.warn("No metrics to flush despite unflushed records; skipping flush");
-                return;
+                return new FlushResult(FlushStatus.SKIPPED, unflushed.size());
             }
 
             var dto = new MetricResourceDTO().hosts(nodeDTOs);
@@ -346,11 +367,18 @@ public class MetricCollectionServiceImpl implements MetricCollectionUseCase {
                     resourceMetricRepository.deleteAllByIdInBatch(flushedIds);
                 }
                 log.debug("Flushed {} metrics to VIPLEV", unflushed.size());
+                return new FlushResult(FlushStatus.SENT, unflushed.size());
             } catch (Exception e) {
-                log.warn("Failed to send resource metrics to VIPLEV; will retry on next flush", e);
+                if (allowRetryLogging) {
+                    log.warn("Failed to send resource metrics to VIPLEV; will retry on next flush", e);
+                } else {
+                    log.warn("Failed to send resource metrics to VIPLEV during stopCollection", e);
+                }
+                return new FlushResult(FlushStatus.FAILED, unflushed.size());
             }
         } catch (Exception e) {
             log.warn("Unexpected error in flushMetrics", e);
+            return new FlushResult(FlushStatus.FAILED, 0);
         }
     }
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -20,6 +20,8 @@ spring.liquibase.change-log=classpath:db/changelog/db.changelog-master.yaml
 # Exporter images
 agent.cadvisor-image=${VIPLEV_CADVISOR_IMAGE:gcr.io/cadvisor/cadvisor:v0.51.0}
 agent.node-exporter-image=${VIPLEV_NODE_EXPORTER_IMAGE:prom/node-exporter:v1.9.0}
+agent.cadvisor-container-name=${VIPLEV_CADVISOR_CONTAINER_NAME:viplev-cadvisor}
+agent.node-exporter-container-name=${VIPLEV_NODE_EXPORTER_CONTAINER_NAME:viplev-node-exporter}
 
 # Exporter ports
 agent.node-exporter-port=${VIPLEV_NODE_EXPORTER_PORT:9100}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -26,6 +26,7 @@ agent.node-exporter-container-name=${VIPLEV_NODE_EXPORTER_CONTAINER_NAME:viplev-
 # Exporter ports
 agent.node-exporter-port=${VIPLEV_NODE_EXPORTER_PORT:9100}
 agent.cadvisor-port=${VIPLEV_CADVISOR_PORT:8080}
+agent.clear-buffered-metrics-on-start=${VIPLEV_CLEAR_BUFFERED_METRICS_ON_START:true}
 
 # Message polling
 agent.message-polling-enabled=${VIPLEV_MESSAGE_POLLING_ENABLED:true}

--- a/src/test/java/dk/viplev/agent/adapter/outbound/container/docker/ExporterLifecycleManagerTest.java
+++ b/src/test/java/dk/viplev/agent/adapter/outbound/container/docker/ExporterLifecycleManagerTest.java
@@ -63,7 +63,9 @@ class ExporterLifecycleManagerTest {
         manager = spy(new ExporterLifecycleManager(
                 dockerClient,
                 "gcr.io/cadvisor/cadvisor:v0.51.0",
-                "prom/node-exporter:v1.9.0"
+                "prom/node-exporter:v1.9.0",
+                ExporterLifecycleManager.CADVISOR_CONTAINER_NAME,
+                ExporterLifecycleManager.NODE_EXPORTER_CONTAINER_NAME
         ));
         lenient().doReturn("test-agent-container-id").when(manager).readSelfContainerId();
         lenient().doReturn(false).when(manager).isSwarmActive();

--- a/src/test/java/dk/viplev/agent/adapter/outbound/metrics/cadvisor/CadvisorAdapterTest.java
+++ b/src/test/java/dk/viplev/agent/adapter/outbound/metrics/cadvisor/CadvisorAdapterTest.java
@@ -216,6 +216,27 @@ class CadvisorAdapterTest {
         assertThat(adapter.scrapeAllContainerStats(BASE_URL).get(CONTAINER_ID).memoryLimitBytes()).isZero();
     }
 
+    @Test
+    void scrapeAllContainerStats_memoryLimitZeroWhenUnlimitedSentinel() {
+        String json = """
+                {
+                  "/system.slice/docker-43fba5afb3a841531c2e2c330a510d997f139c90d1de14c7ec437403c23cd039.scope": {
+                    "id": "43fba5afb3a841531c2e2c330a510d997f139c90d1de14c7ec437403c23cd039",
+                    "aliases": ["nginx", "43fba5afb3a841531c2e2c330a510d997f139c90d1de14c7ec437403c23cd039"],
+                    "spec": { "memory": { "limit": 18446744073709551615 } },
+                    "stats": [{ "timestamp": "2024-01-01T12:00:00Z",
+                                "cpu": { "usage": { "total": 0 } },
+                                "memory": { "usage": 12345678 },
+                                "network": { "interfaces": [] },
+                                "diskio": { "io_service_bytes": [] } }]
+                  }
+                }
+                """;
+        mockRestTemplate(json);
+
+        assertThat(adapter.scrapeAllContainerStats(BASE_URL).get(CONTAINER_ID).memoryLimitBytes()).isZero();
+    }
+
     // -- Helper --
 
     @SuppressWarnings("unchecked")

--- a/src/test/java/dk/viplev/agent/adapter/outbound/metrics/cadvisor/CadvisorAdapterTest.java
+++ b/src/test/java/dk/viplev/agent/adapter/outbound/metrics/cadvisor/CadvisorAdapterTest.java
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.when;
 class CadvisorAdapterTest {
 
     private static final String BASE_URL = "http://viplev-cadvisor:8080";
+    private static final String CONTAINER_ID = "43fba5afb3a841531c2e2c330a510d997f139c90d1de14c7ec437403c23cd039";
 
     @Mock
     private RestTemplate restTemplate;
@@ -40,7 +41,9 @@ class CadvisorAdapterTest {
         // Two samples 1 second apart. CPU delta = 1e9 ns over 1e9 ns time → 100%
         String json = """
                 {
-                  "/docker/abc123": {
+                  "/system.slice/docker-43fba5afb3a841531c2e2c330a510d997f139c90d1de14c7ec437403c23cd039.scope": {
+                    "id": "43fba5afb3a841531c2e2c330a510d997f139c90d1de14c7ec437403c23cd039",
+                    "aliases": ["nginx", "43fba5afb3a841531c2e2c330a510d997f139c90d1de14c7ec437403c23cd039"],
                     "spec": { "memory": { "limit": 536870912 } },
                     "stats": [
                       {
@@ -83,8 +86,8 @@ class CadvisorAdapterTest {
 
         Map<String, ContainerStats> result = adapter.scrapeAllContainerStats(BASE_URL);
 
-        assertThat(result).containsKey("abc123");
-        ContainerStats stats = result.get("abc123");
+        assertThat(result).containsKey(CONTAINER_ID);
+        ContainerStats stats = result.get(CONTAINER_ID);
 
         // cpuDelta=1e9 ns, timeDelta=1000ms=1e9 ns → (1e9/1e9)*100 = 100%
         assertThat(stats.cpuPercentage()).isCloseTo(100.0, within(0.01));
@@ -103,7 +106,9 @@ class CadvisorAdapterTest {
     void scrapeAllContainerStats_cpuIsZeroWithOneSample() {
         String json = """
                 {
-                  "/docker/abc123": {
+                  "/system.slice/docker-43fba5afb3a841531c2e2c330a510d997f139c90d1de14c7ec437403c23cd039.scope": {
+                    "id": "43fba5afb3a841531c2e2c330a510d997f139c90d1de14c7ec437403c23cd039",
+                    "aliases": ["nginx", "43fba5afb3a841531c2e2c330a510d997f139c90d1de14c7ec437403c23cd039"],
                     "spec": { "memory": { "limit": 0 } },
                     "stats": [
                       {
@@ -121,14 +126,16 @@ class CadvisorAdapterTest {
 
         Map<String, ContainerStats> result = adapter.scrapeAllContainerStats(BASE_URL);
 
-        assertThat(result.get("abc123").cpuPercentage()).isZero();
+        assertThat(result.get(CONTAINER_ID).cpuPercentage()).isZero();
     }
 
     @Test
     void scrapeAllContainerStats_excludesLoopbackNetwork() {
         String json = """
                 {
-                  "/docker/abc123": {
+                  "/system.slice/docker-43fba5afb3a841531c2e2c330a510d997f139c90d1de14c7ec437403c23cd039.scope": {
+                    "id": "43fba5afb3a841531c2e2c330a510d997f139c90d1de14c7ec437403c23cd039",
+                    "aliases": ["nginx", "43fba5afb3a841531c2e2c330a510d997f139c90d1de14c7ec437403c23cd039"],
                     "spec": { "memory": { "limit": 0 } },
                     "stats": [
                       {
@@ -149,7 +156,7 @@ class CadvisorAdapterTest {
                 """;
         mockRestTemplate(json);
 
-        ContainerStats stats = adapter.scrapeAllContainerStats(BASE_URL).get("abc123");
+        ContainerStats stats = adapter.scrapeAllContainerStats(BASE_URL).get(CONTAINER_ID);
 
         assertThat(stats.networkInBytes()).isEqualTo(80_000L);
         assertThat(stats.networkOutBytes()).isEqualTo(40_000L);
@@ -159,7 +166,9 @@ class CadvisorAdapterTest {
     void scrapeAllContainerStats_excludesNonDockerContainers() {
         String json = """
                 {
-                  "/docker/abc123": {
+                  "/system.slice/docker-43fba5afb3a841531c2e2c330a510d997f139c90d1de14c7ec437403c23cd039.scope": {
+                    "id": "43fba5afb3a841531c2e2c330a510d997f139c90d1de14c7ec437403c23cd039",
+                    "aliases": ["nginx", "43fba5afb3a841531c2e2c330a510d997f139c90d1de14c7ec437403c23cd039"],
                     "spec": { "memory": { "limit": 0 } },
                     "stats": [{ "timestamp": "2024-01-01T12:00:00Z",
                                 "cpu": { "usage": { "total": 0 } },
@@ -167,7 +176,9 @@ class CadvisorAdapterTest {
                                 "network": { "interfaces": [] },
                                 "diskio": { "io_service_bytes": [] } }]
                   },
-                  "/system.slice/docker.service": {
+                  "/": {
+                    "id": "",
+                    "aliases": ["root"],
                     "spec": { "memory": { "limit": 0 } },
                     "stats": [{ "timestamp": "2024-01-01T12:00:00Z",
                                 "cpu": { "usage": { "total": 0 } },
@@ -181,14 +192,16 @@ class CadvisorAdapterTest {
 
         Map<String, ContainerStats> result = adapter.scrapeAllContainerStats(BASE_URL);
 
-        assertThat(result).containsOnlyKeys("abc123");
+        assertThat(result).containsOnlyKeys(CONTAINER_ID);
     }
 
     @Test
     void scrapeAllContainerStats_memoryLimitZeroWhenUnset() {
         String json = """
                 {
-                  "/docker/abc123": {
+                  "/system.slice/docker-43fba5afb3a841531c2e2c330a510d997f139c90d1de14c7ec437403c23cd039.scope": {
+                    "id": "43fba5afb3a841531c2e2c330a510d997f139c90d1de14c7ec437403c23cd039",
+                    "aliases": ["nginx", "43fba5afb3a841531c2e2c330a510d997f139c90d1de14c7ec437403c23cd039"],
                     "spec": { "memory": { "limit": 0 } },
                     "stats": [{ "timestamp": "2024-01-01T12:00:00Z",
                                 "cpu": { "usage": { "total": 0 } },
@@ -200,7 +213,7 @@ class CadvisorAdapterTest {
                 """;
         mockRestTemplate(json);
 
-        assertThat(adapter.scrapeAllContainerStats(BASE_URL).get("abc123").memoryLimitBytes()).isZero();
+        assertThat(adapter.scrapeAllContainerStats(BASE_URL).get(CONTAINER_ID).memoryLimitBytes()).isZero();
     }
 
     // -- Helper --
@@ -223,7 +236,7 @@ class CadvisorAdapterTest {
                     mapper.getTypeFactory().constructType(type));
 
             when(restTemplate.exchange(
-                    eq(BASE_URL + "/api/v2.0/stats?type=docker&count=2"),
+                    eq(BASE_URL + "/api/v1.3/docker"),
                     eq(HttpMethod.GET),
                     isNull(),
                     any(ParameterizedTypeReference.class))

--- a/src/test/java/dk/viplev/agent/domain/services/MetricCollectionServiceImplTest.java
+++ b/src/test/java/dk/viplev/agent/domain/services/MetricCollectionServiceImplTest.java
@@ -101,6 +101,7 @@ class MetricCollectionServiceImplTest {
                 nodeDiscoveryPort, resourceMetricRepository, viplevApiPort, resourceMetricMapper,
                 9100, 8080,
                 "viplev-node-exporter", "viplev-cadvisor",
+                true,
                 mockExecutor);
     }
 

--- a/src/test/java/dk/viplev/agent/domain/services/MetricCollectionServiceImplTest.java
+++ b/src/test/java/dk/viplev/agent/domain/services/MetricCollectionServiceImplTest.java
@@ -99,7 +99,9 @@ class MetricCollectionServiceImplTest {
         service = new MetricCollectionServiceImpl(
                 nodeExporterPort, cadvisorPort, containerPort,
                 nodeDiscoveryPort, resourceMetricRepository, viplevApiPort, resourceMetricMapper,
-                9100, 8080, mockExecutor);
+                9100, 8080,
+                "viplev-node-exporter", "viplev-cadvisor",
+                mockExecutor);
     }
 
     @Test

--- a/src/test/java/dk/viplev/agent/domain/services/MetricCollectionServiceImplTest.java
+++ b/src/test/java/dk/viplev/agent/domain/services/MetricCollectionServiceImplTest.java
@@ -8,6 +8,7 @@ import dk.viplev.agent.domain.model.NodeInfo;
 import dk.viplev.agent.domain.model.ResourceMetric;
 import dk.viplev.agent.domain.model.TargetType;
 import dk.viplev.agent.generated.model.MetricResourceDTO;
+import dk.viplev.agent.generated.model.MetricResourceServiceDTO;
 import dk.viplev.agent.port.outbound.container.ContainerPort;
 import dk.viplev.agent.port.outbound.db.ResourceMetricRepository;
 import dk.viplev.agent.port.outbound.discovery.NodeDiscoveryPort;
@@ -118,8 +119,8 @@ class MetricCollectionServiceImplTest {
         // Invoke collectMetrics directly (deterministic, no timeout needed)
         scheduledRunnables.get(0).run();
 
-        verify(nodeExporterPort).scrapeHostStats("http://192.168.1.10:9100");
-        verify(cadvisorPort).scrapeAllContainerStats("http://192.168.1.10:8080");
+        verify(nodeExporterPort).scrapeHostStats("http://viplev-node-exporter:9100");
+        verify(cadvisorPort).scrapeAllContainerStats("http://viplev-cadvisor:8080");
     }
 
     @Test
@@ -129,7 +130,6 @@ class MetricCollectionServiceImplTest {
                 serviceMetric("nginx", "machine-abc")
         );
         when(resourceMetricRepository.findByFlushedFalseOrderByCollectedAtAsc()).thenReturn(unflushedMetrics);
-        when(resourceMetricRepository.saveAll(any())).thenAnswer(inv -> inv.getArgument(0));
 
         service.startCollection(BENCHMARK_ID, RUN_ID);
         service.stopCollection();
@@ -145,7 +145,6 @@ class MetricCollectionServiceImplTest {
 
         when(resourceMetricRepository.findByFlushedFalseOrderByCollectedAtAsc())
                 .thenReturn(List.of(hostMetric, serviceMetric1, serviceMetric2));
-        when(resourceMetricRepository.saveAll(any())).thenAnswer(inv -> inv.getArgument(0));
 
         service.startCollection(BENCHMARK_ID, RUN_ID);
         service.flushMetrics();
@@ -162,6 +161,7 @@ class MetricCollectionServiceImplTest {
         assertThat(nodeDTO.getServices()).hasSize(2);
         assertThat(nodeDTO.getServices().stream().map(s -> s.getServiceName()))
                 .containsExactlyInAnyOrder("nginx", "redis");
+        assertThat(nodeDTO.getServices().stream().allMatch(s -> s.getMetrics().size() == 1)).isTrue();
     }
 
     @Test
@@ -173,7 +173,6 @@ class MetricCollectionServiceImplTest {
 
         when(resourceMetricRepository.findByFlushedFalseOrderByCollectedAtAsc())
                 .thenReturn(List.of(hostMetricAbc, hostMetricXyz, serviceAbcNginx, serviceXyzPostgres));
-        when(resourceMetricRepository.saveAll(any())).thenAnswer(inv -> inv.getArgument(0));
 
         service.startCollection(BENCHMARK_ID, RUN_ID);
         service.flushMetrics();
@@ -198,12 +197,38 @@ class MetricCollectionServiceImplTest {
     }
 
     @Test
+    void flushMetrics_manyServices_eachServiceKeepsOwnDatapoints() {
+        var allMetrics = new ArrayList<ResourceMetric>();
+        allMetrics.add(hostMetric("machine-abc"));
+        for (int i = 1; i <= 7; i++) {
+            allMetrics.add(serviceMetric("service-" + i, "machine-abc"));
+        }
+
+        when(resourceMetricRepository.findByFlushedFalseOrderByCollectedAtAsc()).thenReturn(allMetrics);
+
+        service.startCollection(BENCHMARK_ID, RUN_ID);
+        service.flushMetrics();
+
+        var captor = ArgumentCaptor.forClass(MetricResourceDTO.class);
+        verify(viplevApiPort).sendResourceMetrics(any(), any(), captor.capture());
+
+        var dto = captor.getValue();
+        assertThat(dto.getHosts()).hasSize(1);
+
+        var nodeDTO = dto.getHosts().getFirst();
+        assertThat(nodeDTO.getServices()).hasSize(7);
+        assertThat(nodeDTO.getServices().stream().allMatch(s -> s.getMetrics().size() == 1)).isTrue();
+        assertThat(nodeDTO.getServices().stream().map(MetricResourceServiceDTO::getServiceName))
+                .containsExactlyInAnyOrder(
+                        "service-1", "service-2", "service-3", "service-4", "service-5", "service-6", "service-7");
+    }
+
+    @Test
     void flushMetrics_serviceMetricsWithoutHostMetrics_stillFlushes() {
         var serviceMetric = serviceMetric("nginx", "machine-abc");
 
         when(resourceMetricRepository.findByFlushedFalseOrderByCollectedAtAsc())
                 .thenReturn(List.of(serviceMetric));
-        when(resourceMetricRepository.saveAll(any())).thenAnswer(inv -> inv.getArgument(0));
 
         service.startCollection(BENCHMARK_ID, RUN_ID);
         service.flushMetrics();
@@ -233,7 +258,7 @@ class MetricCollectionServiceImplTest {
         service.flushMetrics();
 
         assertThat(metric.isFlushed()).isFalse();
-        verify(resourceMetricRepository, never()).saveAll(any());
+        verify(resourceMetricRepository, never()).deleteAllByIdInBatch(any());
     }
 
     @Test
@@ -348,7 +373,6 @@ class MetricCollectionServiceImplTest {
 
         when(resourceMetricRepository.findByFlushedFalseOrderByCollectedAtAsc())
                 .thenReturn(new ArrayList<>(List.of(nullMachineIdMetric, validMetric)));
-        when(resourceMetricRepository.saveAll(any())).thenAnswer(inv -> inv.getArgument(0));
 
         service.startCollection(BENCHMARK_ID, RUN_ID);
         service.flushMetrics();
@@ -362,6 +386,64 @@ class MetricCollectionServiceImplTest {
         var dto = captor.getValue();
         assertThat(dto.getHosts()).hasSize(1);
         assertThat(dto.getHosts().getFirst().getMachineId()).isEqualTo("machine-abc");
+    }
+
+    @Test
+    void scraperState_firstFailure_transitionsToDegraded() {
+        var transition = service.markScraperFailure("machine-abc", MetricCollectionServiceImpl.ScraperType.NODE_EXPORTER);
+
+        assertThat(transition).isEqualTo(MetricCollectionServiceImpl.ScraperTransition.DEGRADED);
+        assertThat(service.getScraperHealth("machine-abc", MetricCollectionServiceImpl.ScraperType.NODE_EXPORTER))
+                .isEqualTo(MetricCollectionServiceImpl.ScraperHealth.DEGRADED);
+    }
+
+    @Test
+    void scraperState_repeatedFailure_doesNotRetriggerTransition() {
+        service.markScraperFailure("machine-abc", MetricCollectionServiceImpl.ScraperType.CADVISOR);
+
+        var transition = service.markScraperFailure("machine-abc", MetricCollectionServiceImpl.ScraperType.CADVISOR);
+
+        assertThat(transition).isEqualTo(MetricCollectionServiceImpl.ScraperTransition.NONE);
+        assertThat(service.getScraperHealth("machine-abc", MetricCollectionServiceImpl.ScraperType.CADVISOR))
+                .isEqualTo(MetricCollectionServiceImpl.ScraperHealth.DEGRADED);
+    }
+
+    @Test
+    void scraperState_recovery_logsAsSingleTransition() {
+        service.markScraperFailure("machine-abc", MetricCollectionServiceImpl.ScraperType.NODE_EXPORTER);
+
+        var firstRecovery = service.markScraperSuccess("machine-abc", MetricCollectionServiceImpl.ScraperType.NODE_EXPORTER);
+        var secondRecovery = service.markScraperSuccess("machine-abc", MetricCollectionServiceImpl.ScraperType.NODE_EXPORTER);
+
+        assertThat(firstRecovery).isEqualTo(MetricCollectionServiceImpl.ScraperTransition.RECOVERED);
+        assertThat(secondRecovery).isEqualTo(MetricCollectionServiceImpl.ScraperTransition.NONE);
+        assertThat(service.getScraperHealth("machine-abc", MetricCollectionServiceImpl.ScraperType.NODE_EXPORTER))
+                .isEqualTo(MetricCollectionServiceImpl.ScraperHealth.HEALTHY);
+    }
+
+    @Test
+    void scraperState_failureAfterRecovery_startsNewFailurePeriod() {
+        service.markScraperFailure("machine-abc", MetricCollectionServiceImpl.ScraperType.CADVISOR);
+        service.markScraperSuccess("machine-abc", MetricCollectionServiceImpl.ScraperType.CADVISOR);
+
+        var transition = service.markScraperFailure("machine-abc", MetricCollectionServiceImpl.ScraperType.CADVISOR);
+
+        assertThat(transition).isEqualTo(MetricCollectionServiceImpl.ScraperTransition.DEGRADED);
+        assertThat(service.getScraperHealth("machine-abc", MetricCollectionServiceImpl.ScraperType.CADVISOR))
+                .isEqualTo(MetricCollectionServiceImpl.ScraperHealth.DEGRADED);
+    }
+
+    @Test
+    void pruneScraperStates_removesMissingNodes() {
+        service.markScraperFailure("machine-abc", MetricCollectionServiceImpl.ScraperType.NODE_EXPORTER);
+        service.markScraperFailure("machine-xyz", MetricCollectionServiceImpl.ScraperType.CADVISOR);
+
+        service.pruneScraperStates(List.of(TEST_NODE));
+
+        assertThat(service.getScraperHealth("machine-abc", MetricCollectionServiceImpl.ScraperType.NODE_EXPORTER))
+                .isEqualTo(MetricCollectionServiceImpl.ScraperHealth.DEGRADED);
+        assertThat(service.getScraperHealth("machine-xyz", MetricCollectionServiceImpl.ScraperType.CADVISOR))
+                .isNull();
     }
 
     // --- Helpers ---

--- a/src/test/resources/application-test.properties
+++ b/src/test/resources/application-test.properties
@@ -11,3 +11,5 @@ agent.k6-log-max-bytes=4000
 agent.k6-output-log-max-bytes=500000
 agent.run-status-reason-max-length=2000
 agent.message-polling-enabled=true
+agent.cadvisor-container-name=viplev-cadvisor
+agent.node-exporter-container-name=viplev-node-exporter

--- a/src/test/resources/application-test.properties
+++ b/src/test/resources/application-test.properties
@@ -13,3 +13,4 @@ agent.run-status-reason-max-length=2000
 agent.message-polling-enabled=true
 agent.cadvisor-container-name=viplev-cadvisor
 agent.node-exporter-container-name=viplev-node-exporter
+agent.clear-buffered-metrics-on-start=true


### PR DESCRIPTION
## Summary
- Stabilizes cAdvisor ingestion by switching to a compatible endpoint, handling cgroups v2 container identity reliably, and tolerating unlimited memory limits without deserialization failures.
- Reduces noisy scraper failure logs and introduces scraper degraded/recovered state transitions so transient failures do not spam warnings.
- Prevents SQLite lock contention and stale metric carry-over by serializing DB access in metric collection/flush and clearing buffered rows at run start/stop, with successful flushes now deleting sent rows.

## Validation
- Ran `./gradlew test --tests dk.viplev.agent.adapter.outbound.metrics.cadvisor.CadvisorAdapterTest`
- Ran `./gradlew test --tests dk.viplev.agent.domain.services.MetricCollectionServiceImplTest`
- Ran full test suite with `./gradlew test`