### PR TITLE
feat(metrics): align resource metrics payload with replica-based schema

### DIFF
--- a/src/main/java/dk/viplev/agent/adapter/outbound/container/docker/DockerContainerAdapter.java
+++ b/src/main/java/dk/viplev/agent/adapter/outbound/container/docker/DockerContainerAdapter.java
@@ -333,9 +333,13 @@ public class DockerContainerAdapter implements ContainerPort, Closeable {
         LocalDateTime startedAt = null;
         if (inspection.getState() != null && inspection.getState().getStartedAt() != null) {
             try {
-                startedAt = LocalDateTime.parse(
+                // Docker returns RFC3339 timestamp with offset (e.g., "2026-04-19T20:00:00.123456789Z")
+                // Parse as OffsetDateTime first, then convert to LocalDateTime in UTC
+                startedAt = java.time.OffsetDateTime.parse(
                         inspection.getState().getStartedAt(),
-                        java.time.format.DateTimeFormatter.ISO_OFFSET_DATE_TIME);
+                        java.time.format.DateTimeFormatter.ISO_OFFSET_DATE_TIME)
+                        .atZoneSameInstant(java.time.ZoneOffset.UTC)
+                        .toLocalDateTime();
             } catch (Exception e) {
                 log.debug("Failed to parse startedAt for container {}: {}", container.getId(), e.getMessage());
             }

--- a/src/main/java/dk/viplev/agent/adapter/outbound/container/docker/DockerContainerAdapter.java
+++ b/src/main/java/dk/viplev/agent/adapter/outbound/container/docker/DockerContainerAdapter.java
@@ -32,6 +32,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -324,12 +325,30 @@ public class DockerContainerAdapter implements ContainerPort, Closeable {
                 ? container.getNames()[0].replaceFirst("^/", "")
                 : "";
 
+        // Extract service name from Swarm label (if present)
+        Map<String, String> labels = container.getLabels() != null ? container.getLabels() : Map.of();
+        String serviceName = labels.get("com.docker.swarm.service.name");
+
+        // Extract startedAt timestamp
+        LocalDateTime startedAt = null;
+        if (inspection.getState() != null && inspection.getState().getStartedAt() != null) {
+            try {
+                startedAt = LocalDateTime.parse(
+                        inspection.getState().getStartedAt(),
+                        java.time.format.DateTimeFormatter.ISO_OFFSET_DATE_TIME);
+            } catch (Exception e) {
+                log.debug("Failed to parse startedAt for container {}: {}", container.getId(), e.getMessage());
+            }
+        }
+
         return new ContainerInfo(
                 container.getId(),
                 name,
+                serviceName,
                 container.getImage(),
                 container.getImageId(),
                 container.getState(),
+                startedAt,
                 hostConfig != null ? hostConfig.getNanoCPUs() : null,
                 hostConfig != null ? longFromInt(hostConfig.getCpuShares()) : null,
                 hostConfig != null ? hostConfig.getMemory() : null,

--- a/src/main/java/dk/viplev/agent/domain/model/ContainerInfo.java
+++ b/src/main/java/dk/viplev/agent/domain/model/ContainerInfo.java
@@ -1,11 +1,15 @@
 package dk.viplev.agent.domain.model;
 
+import java.time.LocalDateTime;
+
 public record ContainerInfo(
         String id,
         String name,
+        String serviceName,
         String imageName,
         String imageSha,
         String status,
+        LocalDateTime startedAt,
         Long cpuLimit,
         Long cpuReservation,
         Long memoryLimit,

--- a/src/main/java/dk/viplev/agent/domain/model/ResourceMetric.java
+++ b/src/main/java/dk/viplev/agent/domain/model/ResourceMetric.java
@@ -32,6 +32,12 @@ public class ResourceMetric {
     @Column(name = "machine_id", nullable = false)
     private String machineId;
 
+    @Column(name = "container_id")
+    private String containerId;
+
+    @Column(name = "started_at")
+    private LocalDateTime startedAt;
+
     @Column(name = "cpu_percentage")
     private Double cpuPercentage;
 

--- a/src/main/java/dk/viplev/agent/domain/services/MetricCollectionServiceImpl.java
+++ b/src/main/java/dk/viplev/agent/domain/services/MetricCollectionServiceImpl.java
@@ -360,8 +360,19 @@ public class MetricCollectionServiceImpl implements MetricCollectionUseCase {
                 }
             }
 
+            // Filter out SERVICE metrics with null containerId and delete them
+            boolean hasNullContainerId = unflushed.stream()
+                    .anyMatch(m -> m.getTargetType() == TargetType.SERVICE && m.getContainerId() == null);
+            if (hasNullContainerId) {
+                log.warn("Deleting legacy SERVICE metrics with null containerId — these cannot be flushed");
+                synchronized (metricsDbLock) {
+                    resourceMetricRepository.deleteByTargetTypeAndContainerIdIsNull(TargetType.SERVICE);
+                }
+            }
+
             unflushed = unflushed.stream()
                     .filter(m -> m.getMachineId() != null)
+                    .filter(m -> m.getTargetType() != TargetType.SERVICE || m.getContainerId() != null)
                     .toList();
             if (unflushed.isEmpty()) {
                 return new FlushResult(FlushStatus.SKIPPED, 0);
@@ -382,7 +393,7 @@ public class MetricCollectionServiceImpl implements MetricCollectionUseCase {
                                     ResourceMetric::getTargetName,
                                     LinkedHashMap::new,
                                     Collectors.groupingBy(
-                                            m -> m.getContainerId() != null ? m.getContainerId() : "unknown",
+                                            ResourceMetric::getContainerId,
                                             LinkedHashMap::new,
                                             Collectors.toList()))));
 

--- a/src/main/java/dk/viplev/agent/domain/services/MetricCollectionServiceImpl.java
+++ b/src/main/java/dk/viplev/agent/domain/services/MetricCollectionServiceImpl.java
@@ -7,6 +7,7 @@ import dk.viplev.agent.config.ExporterConstants;
 import dk.viplev.agent.generated.model.MetricResourceDTO;
 import dk.viplev.agent.generated.model.MetricResourceNodeDTO;
 import dk.viplev.agent.generated.model.MetricResourceServiceDTO;
+import dk.viplev.agent.generated.model.MetricResourceServiceReplicaDTO;
 import dk.viplev.agent.port.inbound.MetricCollectionUseCase;
 import dk.viplev.agent.port.outbound.container.ContainerPort;
 import dk.viplev.agent.port.outbound.db.ResourceMetricRepository;
@@ -286,6 +287,7 @@ public class MetricCollectionServiceImpl implements MetricCollectionUseCase {
                                 .targetType(TargetType.SERVICE)
                                 .targetName(containerName)
                                 .machineId(node.machineId())
+                                .containerId(containerId)
                                 .cpuPercentage(stats.cpuPercentage())
                                 .memoryUsageBytes((double) stats.memoryUsageBytes())
                                 .memoryLimitBytes((double) stats.memoryLimitBytes())
@@ -355,25 +357,53 @@ public class MetricCollectionServiceImpl implements MetricCollectionUseCase {
                     .filter(m -> m.getTargetType() == TargetType.HOST)
                     .collect(Collectors.groupingBy(ResourceMetric::getMachineId, LinkedHashMap::new, Collectors.toList()));
 
-            // Group service metrics first by machineId, then by targetName
+            // Group service metrics: machineId -> serviceName -> containerId -> metrics[]
             var serviceMetrics = unflushed.stream()
                     .filter(m -> m.getTargetType() == TargetType.SERVICE)
                     .collect(Collectors.groupingBy(
                             ResourceMetric::getMachineId,
                             LinkedHashMap::new,
-                            Collectors.groupingBy(ResourceMetric::getTargetName, LinkedHashMap::new, Collectors.toList())));
+                            Collectors.groupingBy(
+                                    ResourceMetric::getTargetName,
+                                    LinkedHashMap::new,
+                                    Collectors.groupingBy(
+                                            m -> m.getContainerId() != null ? m.getContainerId() : "unknown",
+                                            LinkedHashMap::new,
+                                            Collectors.toList()))));
 
             List<MetricResourceNodeDTO> nodeDTOs = new ArrayList<>();
 
             // Build node DTOs from host metrics, attaching only services with the same machineId
             for (var entry : hostMetrics.entrySet()) {
                 String machineId = entry.getKey();
-                Map<String, List<ResourceMetric>> servicesForNode = serviceMetrics.getOrDefault(machineId, new LinkedHashMap<>());
+                var servicesForNode = serviceMetrics.getOrDefault(machineId, new LinkedHashMap<>());
 
                 List<MetricResourceServiceDTO> serviceDTOs = servicesForNode.entrySet().stream()
-                        .map(e -> new MetricResourceServiceDTO()
-                                .serviceName(e.getKey())
-                                .metrics(resourceMetricMapper.toDataPoints(e.getValue())))
+                        .map(serviceEntry -> {
+                            String serviceName = serviceEntry.getKey();
+                            var replicaMap = serviceEntry.getValue();
+
+                            List<MetricResourceServiceReplicaDTO> replicaDTOs = replicaMap.entrySet().stream()
+                                    .map(replicaEntry -> {
+                                        String containerId = replicaEntry.getKey();
+                                        List<ResourceMetric> replicaMetrics = replicaEntry.getValue();
+                                        LocalDateTime startedAt = replicaMetrics.stream()
+                                                .map(ResourceMetric::getStartedAt)
+                                                .filter(java.util.Objects::nonNull)
+                                                .findFirst()
+                                                .orElse(null);
+
+                                        return new MetricResourceServiceReplicaDTO()
+                                                .containerId(containerId)
+                                                .startedAt(startedAt)
+                                                .metrics(resourceMetricMapper.toDataPoints(replicaMetrics));
+                                    })
+                                    .toList();
+
+                            return new MetricResourceServiceDTO()
+                                    .serviceName(serviceName)
+                                    .replicas(replicaDTOs);
+                        })
                         .toList();
 
                 var nodeDTO = new MetricResourceNodeDTO()
@@ -389,10 +419,34 @@ public class MetricCollectionServiceImpl implements MetricCollectionUseCase {
                 if (hostMetrics.containsKey(machineId)) {
                     continue;
                 }
-                List<MetricResourceServiceDTO> serviceDTOs = entry.getValue().entrySet().stream()
-                        .map(e -> new MetricResourceServiceDTO()
-                                .serviceName(e.getKey())
-                                .metrics(resourceMetricMapper.toDataPoints(e.getValue())))
+                var servicesForNode = entry.getValue();
+
+                List<MetricResourceServiceDTO> serviceDTOs = servicesForNode.entrySet().stream()
+                        .map(serviceEntry -> {
+                            String serviceName = serviceEntry.getKey();
+                            Map<String, List<ResourceMetric>> replicaMap = serviceEntry.getValue();
+
+                            List<MetricResourceServiceReplicaDTO> replicaDTOs = replicaMap.entrySet().stream()
+                                    .map(replicaEntry -> {
+                                        String containerId = replicaEntry.getKey();
+                                        List<ResourceMetric> replicaMetrics = replicaEntry.getValue();
+                                        LocalDateTime startedAt = replicaMetrics.stream()
+                                                .map(ResourceMetric::getStartedAt)
+                                                .filter(java.util.Objects::nonNull)
+                                                .findFirst()
+                                                .orElse(null);
+
+                                        return new MetricResourceServiceReplicaDTO()
+                                                .containerId(containerId)
+                                                .startedAt(startedAt)
+                                                .metrics(resourceMetricMapper.toDataPoints(replicaMetrics));
+                                    })
+                                    .toList();
+
+                            return new MetricResourceServiceDTO()
+                                    .serviceName(serviceName)
+                                    .replicas(replicaDTOs);
+                        })
                         .toList();
 
                 var nodeDTO = new MetricResourceNodeDTO()

--- a/src/main/java/dk/viplev/agent/domain/services/MetricCollectionServiceImpl.java
+++ b/src/main/java/dk/viplev/agent/domain/services/MetricCollectionServiceImpl.java
@@ -1,6 +1,7 @@
 package dk.viplev.agent.domain.services;
 
 import dk.viplev.agent.domain.mapper.ResourceMetricMapper;
+import dk.viplev.agent.domain.model.ContainerInfo;
 import dk.viplev.agent.domain.model.ResourceMetric;
 import dk.viplev.agent.domain.model.TargetType;
 import dk.viplev.agent.config.ExporterConstants;
@@ -265,13 +266,13 @@ public class MetricCollectionServiceImpl implements MetricCollectionUseCase {
                 try {
                     var containerStatsMap = cadvisorPort.scrapeAllContainerStats(cadvisorUrl);
 
-                    Map<String, String> idToName;
+                    Map<String, ContainerInfo> idToInfo;
                     if (isLocalNode) {
                         var containers = containerPort.listContainers();
-                        idToName = containers.stream()
-                                .collect(Collectors.toMap(c -> c.id(), c -> c.name()));
+                        idToInfo = containers.stream()
+                                .collect(Collectors.toMap(c -> c.id(), c -> c));
                     } else {
-                        idToName = Map.of();
+                        idToInfo = Map.of();
                     }
 
                     for (var entry : containerStatsMap.entrySet()) {
@@ -280,14 +281,28 @@ public class MetricCollectionServiceImpl implements MetricCollectionUseCase {
                         }
                         var containerId = entry.getKey();
                         var stats = entry.getValue();
-                        var containerName = idToName.getOrDefault(containerId, containerId);
+                        var containerInfo = idToInfo.get(containerId);
+
+                        // Determine service name: use Swarm service name if available, otherwise container name
+                        String serviceName;
+                        LocalDateTime startedAt = null;
+                        if (containerInfo != null) {
+                            serviceName = containerInfo.serviceName() != null
+                                    ? containerInfo.serviceName()  // Swarm service
+                                    : containerInfo.name();         // Standalone container
+                            startedAt = containerInfo.startedAt();
+                        } else {
+                            // Fallback for remote nodes where we don't have container info
+                            serviceName = containerId;
+                        }
 
                         var containerMetric = ResourceMetric.builder()
                                 .collectedAt(LocalDateTime.now())
                                 .targetType(TargetType.SERVICE)
-                                .targetName(containerName)
+                                .targetName(serviceName)
                                 .machineId(node.machineId())
                                 .containerId(containerId)
+                                .startedAt(startedAt)
                                 .cpuPercentage(stats.cpuPercentage())
                                 .memoryUsageBytes((double) stats.memoryUsageBytes())
                                 .memoryLimitBytes((double) stats.memoryLimitBytes())

--- a/src/main/java/dk/viplev/agent/port/outbound/db/ResourceMetricRepository.java
+++ b/src/main/java/dk/viplev/agent/port/outbound/db/ResourceMetricRepository.java
@@ -1,9 +1,11 @@
 package dk.viplev.agent.port.outbound.db;
 
 import dk.viplev.agent.domain.model.ResourceMetric;
+import dk.viplev.agent.domain.model.TargetType;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.repository.query.Param;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
@@ -17,4 +19,9 @@ public interface ResourceMetricRepository extends JpaRepository<ResourceMetric, 
     @Transactional
     @Query("DELETE FROM ResourceMetric r WHERE r.machineId IS NULL")
     void deleteByMachineIdIsNull();
+
+    @Modifying
+    @Transactional
+    @Query("DELETE FROM ResourceMetric r WHERE r.targetType = :targetType AND r.containerId IS NULL")
+    void deleteByTargetTypeAndContainerIdIsNull(@Param("targetType") TargetType targetType);
 }

--- a/src/main/resources/db/changelog/changes/003-add-container-id-and-started-at-to-resource-metrics.sql
+++ b/src/main/resources/db/changelog/changes/003-add-container-id-and-started-at-to-resource-metrics.sql
@@ -1,0 +1,9 @@
+-- liquibase formatted sql
+
+-- changeset viplev:003-add-container-id-and-started-at-to-resource-metrics
+ALTER TABLE resource_metrics ADD COLUMN container_id TEXT;
+ALTER TABLE resource_metrics ADD COLUMN started_at TIMESTAMP;
+
+-- For SERVICE type metrics, container_id should be populated
+-- For HOST type metrics, container_id can remain NULL
+-- Migration note: existing SERVICE metrics will have NULL container_id until next collection cycle

--- a/src/main/resources/db/changelog/changes/003-add-container-id-and-started-at-to-resource-metrics.sql
+++ b/src/main/resources/db/changelog/changes/003-add-container-id-and-started-at-to-resource-metrics.sql
@@ -1,6 +1,6 @@
--- liquibase formatted sql
+--liquibase formatted sql
 
--- changeset viplev:003-add-container-id-and-started-at-to-resource-metrics
+--changeset viplev:003-add-container-id-and-started-at-to-resource-metrics
 ALTER TABLE resource_metrics ADD COLUMN container_id TEXT;
 ALTER TABLE resource_metrics ADD COLUMN started_at TIMESTAMP;
 

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -3,3 +3,5 @@ databaseChangeLog:
       file: db/changelog/changes/001-create-resource-metrics-table.sql
   - include:
       file: db/changelog/changes/002-add-machine-id-to-resource-metrics.sql
+  - include:
+      file: db/changelog/changes/003-add-container-id-and-started-at-to-resource-metrics.sql

--- a/src/main/resources/openapi/outbound/openapi.yaml
+++ b/src/main/resources/openapi/outbound/openapi.yaml
@@ -1189,6 +1189,26 @@ components:
             - "d4e5f6a7-b8c9-0123-def0-1234567890ab"
         serviceName:
           type: string
+        replicas:
+          type: array
+          description: Time-series data for each replica of this service
+          items:
+            $ref: '#/components/schemas/RawReplicaTimeSeriesDTO'
+
+    RawReplicaTimeSeriesDTO:
+      type: object
+      description: Time-series resource data for a single replica (container) of a service
+      properties:
+        replicaId:
+          type: string
+          format: uuid
+          examples:
+            - "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+        containerId:
+          type: string
+          description: Docker container ID
+          examples:
+            - "abc123def456"
         dataPoints:
           type: array
           items:
@@ -1591,11 +1611,30 @@ components:
       type: object
       required:
         - serviceName
-        - metrics
+        - replicas
       properties:
         serviceName:
           type: string
           description: Docker service name known by the agent
+        replicas:
+          type: array
+          description: Replica-level metrics for all containers of this service (single container = 1 replica)
+          items:
+            $ref: '#/components/schemas/MetricResourceServiceReplicaDTO'
+
+    MetricResourceServiceReplicaDTO:
+      type: object
+      required:
+        - containerId
+        - metrics
+      properties:
+        containerId:
+          type: string
+          description: Docker container ID
+        startedAt:
+          type: string
+          format: date-time
+          description: When the container was started
         metrics:
           type: array
           items:

--- a/src/test/java/dk/viplev/agent/domain/services/MetricCollectionServiceImplTest.java
+++ b/src/test/java/dk/viplev/agent/domain/services/MetricCollectionServiceImplTest.java
@@ -296,9 +296,46 @@ class MetricCollectionServiceImplTest {
     }
 
     @Test
+    void flushMetrics_swarmServiceWithMultipleReplicas_groupsByServiceName() {
+        var hostMetric = hostMetric("machine-abc");
+        // Three replicas of the same Swarm service
+        var replica1 = serviceMetric("nginx", "machine-abc", "nginx.1.abc123");
+        var replica2 = serviceMetric("nginx", "machine-abc", "nginx.2.def456");
+        var replica3 = serviceMetric("nginx", "machine-abc", "nginx.3.ghi789");
+
+        when(resourceMetricRepository.findByFlushedFalseOrderByCollectedAtAsc())
+                .thenReturn(List.of(hostMetric, replica1, replica2, replica3));
+
+        service.startCollection(BENCHMARK_ID, RUN_ID);
+        service.flushMetrics();
+
+        var captor = ArgumentCaptor.forClass(MetricResourceDTO.class);
+        verify(viplevApiPort).sendResourceMetrics(any(), any(), captor.capture());
+
+        var dto = captor.getValue();
+        assertThat(dto.getHosts()).hasSize(1);
+
+        var nodeDTO = dto.getHosts().getFirst();
+        assertThat(nodeDTO.getServices()).hasSize(1);
+        
+        var serviceDTO = nodeDTO.getServices().getFirst();
+        assertThat(serviceDTO.getServiceName()).isEqualTo("nginx");
+        assertThat(serviceDTO.getReplicas()).hasSize(3);
+        
+        // Verify all three replicas are present with correct container IDs
+        assertThat(serviceDTO.getReplicas().stream()
+                .map(MetricResourceServiceReplicaDTO::getContainerId))
+                .containsExactlyInAnyOrder("nginx.1.abc123", "nginx.2.def456", "nginx.3.ghi789");
+        
+        // Each replica should have metrics
+        assertThat(serviceDTO.getReplicas().stream()
+                .allMatch(r -> r.getMetrics().size() == 1)).isTrue();
+    }
+
+    @Test
     void collectMetrics_persistsHostAndContainerMetrics() {
-        var container = new ContainerInfo("abc123", "nginx", "nginx:latest", "sha256:aaa",
-                "running", null, null, null, null);
+        var container = new ContainerInfo("abc123", "nginx", null, "nginx:latest", "sha256:aaa",
+                "running", null, null, null, null, null);
         when(nodeDiscoveryPort.discoverNodes()).thenReturn(List.of(TEST_NODE));
         when(nodeDiscoveryPort.getLocalNodeId()).thenReturn("machine-abc");
         when(nodeExporterPort.scrapeHostStats(anyString())).thenReturn(SAMPLE_HOST_STATS);
@@ -331,6 +368,64 @@ class MetricCollectionServiceImplTest {
         assertThat(savedMetrics.stream()
                 .filter(m -> m.getTargetType() == TargetType.SERVICE)
                 .findFirst().get().getMachineId()).isEqualTo("machine-abc");
+    }
+
+    @Test
+    void collectMetrics_swarmService_usesServiceNameFromLabel() {
+        // Swarm service container with service name in label
+        var swarmContainer = new ContainerInfo("nginx.1.abc123", "nginx.1.abc123xyz", "nginx",
+                "nginx:latest", "sha256:aaa", "running", null, null, null, null, null);
+        when(nodeDiscoveryPort.discoverNodes()).thenReturn(List.of(TEST_NODE));
+        when(nodeDiscoveryPort.getLocalNodeId()).thenReturn("machine-abc");
+        when(nodeExporterPort.scrapeHostStats(anyString())).thenReturn(SAMPLE_HOST_STATS);
+        when(cadvisorPort.scrapeAllContainerStats(anyString()))
+                .thenReturn(Map.of("nginx.1.abc123", SAMPLE_CONTAINER_STATS));
+        when(containerPort.listContainers()).thenReturn(List.of(swarmContainer));
+
+        var savedMetrics = new ArrayList<ResourceMetric>();
+        when(resourceMetricRepository.save(any())).thenAnswer(inv -> {
+            savedMetrics.add(inv.getArgument(0));
+            return inv.getArgument(0);
+        });
+
+        service.collectMetrics();
+
+        var serviceMetric = savedMetrics.stream()
+                .filter(m -> m.getTargetType() == TargetType.SERVICE)
+                .findFirst().orElseThrow();
+        
+        // Should use service name from label, not container name
+        assertThat(serviceMetric.getTargetName()).isEqualTo("nginx");
+        assertThat(serviceMetric.getContainerId()).isEqualTo("nginx.1.abc123");
+    }
+
+    @Test
+    void collectMetrics_standaloneContainer_usesContainerName() {
+        // Standalone container without service name label
+        var standaloneContainer = new ContainerInfo("abc123", "my-nginx-container", null,
+                "nginx:latest", "sha256:aaa", "running", null, null, null, null, null);
+        when(nodeDiscoveryPort.discoverNodes()).thenReturn(List.of(TEST_NODE));
+        when(nodeDiscoveryPort.getLocalNodeId()).thenReturn("machine-abc");
+        when(nodeExporterPort.scrapeHostStats(anyString())).thenReturn(SAMPLE_HOST_STATS);
+        when(cadvisorPort.scrapeAllContainerStats(anyString()))
+                .thenReturn(Map.of("abc123", SAMPLE_CONTAINER_STATS));
+        when(containerPort.listContainers()).thenReturn(List.of(standaloneContainer));
+
+        var savedMetrics = new ArrayList<ResourceMetric>();
+        when(resourceMetricRepository.save(any())).thenAnswer(inv -> {
+            savedMetrics.add(inv.getArgument(0));
+            return inv.getArgument(0);
+        });
+
+        service.collectMetrics();
+
+        var serviceMetric = savedMetrics.stream()
+                .filter(m -> m.getTargetType() == TargetType.SERVICE)
+                .findFirst().orElseThrow();
+        
+        // Should use container name as service name
+        assertThat(serviceMetric.getTargetName()).isEqualTo("my-nginx-container");
+        assertThat(serviceMetric.getContainerId()).isEqualTo("abc123");
     }
 
     @Test

--- a/src/test/java/dk/viplev/agent/domain/services/MetricCollectionServiceImplTest.java
+++ b/src/test/java/dk/viplev/agent/domain/services/MetricCollectionServiceImplTest.java
@@ -9,6 +9,7 @@ import dk.viplev.agent.domain.model.ResourceMetric;
 import dk.viplev.agent.domain.model.TargetType;
 import dk.viplev.agent.generated.model.MetricResourceDTO;
 import dk.viplev.agent.generated.model.MetricResourceServiceDTO;
+import dk.viplev.agent.generated.model.MetricResourceServiceReplicaDTO;
 import dk.viplev.agent.port.outbound.container.ContainerPort;
 import dk.viplev.agent.port.outbound.db.ResourceMetricRepository;
 import dk.viplev.agent.port.outbound.discovery.NodeDiscoveryPort;
@@ -164,7 +165,16 @@ class MetricCollectionServiceImplTest {
         assertThat(nodeDTO.getServices()).hasSize(2);
         assertThat(nodeDTO.getServices().stream().map(s -> s.getServiceName()))
                 .containsExactlyInAnyOrder("nginx", "redis");
-        assertThat(nodeDTO.getServices().stream().allMatch(s -> s.getMetrics().size() == 1)).isTrue();
+        
+        // Verify replica structure
+        assertThat(nodeDTO.getServices().stream().allMatch(s -> s.getReplicas().size() == 1)).isTrue();
+        assertThat(nodeDTO.getServices().stream()
+                .flatMap(s -> s.getReplicas().stream())
+                .allMatch(r -> r.getMetrics().size() == 1)).isTrue();
+        assertThat(nodeDTO.getServices().stream()
+                .flatMap(s -> s.getReplicas().stream())
+                .map(MetricResourceServiceReplicaDTO::getContainerId))
+                .containsExactlyInAnyOrder("nginx-container-id", "redis-container-id");
     }
 
     @Test
@@ -191,12 +201,18 @@ class MetricCollectionServiceImplTest {
                 .findFirst().orElseThrow();
         assertThat(nodeDTOAbc.getServices()).hasSize(1);
         assertThat(nodeDTOAbc.getServices().getFirst().getServiceName()).isEqualTo("nginx");
+        assertThat(nodeDTOAbc.getServices().getFirst().getReplicas()).hasSize(1);
+        assertThat(nodeDTOAbc.getServices().getFirst().getReplicas().getFirst().getContainerId())
+                .isEqualTo("nginx-container-id");
 
         var nodeDTOXyz = dto.getHosts().stream()
                 .filter(n -> "machine-xyz".equals(n.getMachineId()))
                 .findFirst().orElseThrow();
         assertThat(nodeDTOXyz.getServices()).hasSize(1);
         assertThat(nodeDTOXyz.getServices().getFirst().getServiceName()).isEqualTo("postgres");
+        assertThat(nodeDTOXyz.getServices().getFirst().getReplicas()).hasSize(1);
+        assertThat(nodeDTOXyz.getServices().getFirst().getReplicas().getFirst().getContainerId())
+                .isEqualTo("postgres-container-id");
     }
 
     @Test
@@ -220,7 +236,9 @@ class MetricCollectionServiceImplTest {
 
         var nodeDTO = dto.getHosts().getFirst();
         assertThat(nodeDTO.getServices()).hasSize(7);
-        assertThat(nodeDTO.getServices().stream().allMatch(s -> s.getMetrics().size() == 1)).isTrue();
+        assertThat(nodeDTO.getServices().stream()
+                .allMatch(s -> s.getReplicas().size() == 1 && s.getReplicas().getFirst().getMetrics().size() == 1))
+                .isTrue();
         assertThat(nodeDTO.getServices().stream().map(MetricResourceServiceDTO::getServiceName))
                 .containsExactlyInAnyOrder(
                         "service-1", "service-2", "service-3", "service-4", "service-5", "service-6", "service-7");
@@ -247,6 +265,9 @@ class MetricCollectionServiceImplTest {
         assertThat(nodeDTO.getMetrics()).isEmpty();
         assertThat(nodeDTO.getServices()).hasSize(1);
         assertThat(nodeDTO.getServices().getFirst().getServiceName()).isEqualTo("nginx");
+        assertThat(nodeDTO.getServices().getFirst().getReplicas()).hasSize(1);
+        assertThat(nodeDTO.getServices().getFirst().getReplicas().getFirst().getContainerId())
+                .isEqualTo("nginx-container-id");
     }
 
     @Test
@@ -468,11 +489,16 @@ class MetricCollectionServiceImplTest {
     }
 
     private ResourceMetric serviceMetric(String serviceName, String machineId) {
+        return serviceMetric(serviceName, machineId, serviceName + "-container-id");
+    }
+
+    private ResourceMetric serviceMetric(String serviceName, String machineId, String containerId) {
         return ResourceMetric.builder()
                 .collectedAt(LocalDateTime.now())
                 .targetType(TargetType.SERVICE)
                 .targetName(serviceName)
                 .machineId(machineId)
+                .containerId(containerId)
                 .cpuPercentage(10.0)
                 .memoryUsageBytes(512_000_000.0)
                 .memoryLimitBytes(1_000_000_000.0)

--- a/src/test/java/dk/viplev/agent/domain/services/ServiceDiscoveryServiceImplTest.java
+++ b/src/test/java/dk/viplev/agent/domain/services/ServiceDiscoveryServiceImplTest.java
@@ -49,10 +49,10 @@ class ServiceDiscoveryServiceImplTest {
     @Test
     void syncServices_registersContainersWithHostInfo() {
         var containers = List.of(
-                new ContainerInfo("id1", "nginx", "nginx:latest", "sha256:aaa", "running",
-                        2_000_000_000L, 1024L, 536_870_912L, 268_435_456L),
-                new ContainerInfo("id2", "redis", "redis:7", "sha256:bbb", "running",
-                        null, null, null, null)
+                new ContainerInfo("id1", "nginx", null, "nginx:latest", "sha256:aaa", "running",
+                        null, 2_000_000_000L, 1024L, 536_870_912L, 268_435_456L),
+                new ContainerInfo("id2", "redis", null, "redis:7", "sha256:bbb", "running",
+                        null, null, null, null, null)
         );
         when(containerPort.listContainers()).thenReturn(containers);
         when(nodeDiscoveryPort.discoverNodes()).thenReturn(List.of(testNode));
@@ -86,7 +86,7 @@ class ServiceDiscoveryServiceImplTest {
     void syncServices_multipleNodes_onlyLocalNodeGetsServices() {
         var node2 = new NodeInfo("daemon-id-xyz", "node2", "192.168.1.2", "Linux", "5.15.0", 4, 8_000_000_000L);
         when(containerPort.listContainers()).thenReturn(List.of(
-                new ContainerInfo("id1", "nginx", "nginx:latest", "sha256:aaa", "running", null, null, null, null)));
+                new ContainerInfo("id1", "nginx", null, "nginx:latest", "sha256:aaa", "running", null, null, null, null, null)));
         when(nodeDiscoveryPort.discoverNodes()).thenReturn(List.of(testNode, node2));
         when(nodeDiscoveryPort.getLocalNodeId()).thenReturn("daemon-id-abc123");
 
@@ -105,8 +105,8 @@ class ServiceDiscoveryServiceImplTest {
 
     @Test
     void syncServices_convertsNanoCpusToCores() {
-        var container = new ContainerInfo("id1", "app", "app:1", "sha256:ccc", "running",
-                2_000_000_000L, null, null, null);
+        var container = new ContainerInfo("id1", "app", null, "app:1", "sha256:ccc", "running",
+                null, 2_000_000_000L, null, null, null);
         when(containerPort.listContainers()).thenReturn(List.of(container));
         when(nodeDiscoveryPort.discoverNodes()).thenReturn(List.of(testNode));
         when(nodeDiscoveryPort.getLocalNodeId()).thenReturn("daemon-id-abc123");
@@ -121,8 +121,8 @@ class ServiceDiscoveryServiceImplTest {
 
     @Test
     void syncServices_convertsCpuSharesToCores() {
-        var container = new ContainerInfo("id1", "app", "app:1", "sha256:ccc", "running",
-                null, 1024L, null, null);
+        var container = new ContainerInfo("id1", "app", null, "app:1", "sha256:ccc", "running",
+                null, null, 1024L, null, null);
         when(containerPort.listContainers()).thenReturn(List.of(container));
         when(nodeDiscoveryPort.discoverNodes()).thenReturn(List.of(testNode));
         when(nodeDiscoveryPort.getLocalNodeId()).thenReturn("daemon-id-abc123");
@@ -137,8 +137,8 @@ class ServiceDiscoveryServiceImplTest {
 
     @Test
     void syncServices_handlesNullResourceFields() {
-        var container = new ContainerInfo("id1", "app", "app:1", "sha256:ccc", "running",
-                null, null, null, null);
+        var container = new ContainerInfo("id1", "app", null, "app:1", "sha256:ccc", "running",
+                null, null, null, null, null);
         when(containerPort.listContainers()).thenReturn(List.of(container));
         when(nodeDiscoveryPort.discoverNodes()).thenReturn(List.of(testNode));
         when(nodeDiscoveryPort.getLocalNodeId()).thenReturn("daemon-id-abc123");


### PR DESCRIPTION
## Summary

Implements replica-based resource metrics payload to align with the updated VIPLEV platform API schema. Includes full Docker Swarm and standalone Docker support with automatic detection.

## Changes

### Database & Domain Model
- Added `container_id` and `started_at` columns to `resource_metrics` table via Liquibase migration
- Updated `ResourceMetric` entity with `containerId` and `startedAt` fields
- Extended `ContainerInfo` record with `serviceName` and `startedAt` fields

### Replica-Based Payload Structure
- Restructured metric flush logic from `machineId -> serviceName -> metrics[]`
- To: `machineId -> serviceName -> containerId -> metrics[]`
- Builds `MetricResourceServiceReplicaDTO` for each container replica with:
  - `containerId` (required)
  - `startedAt` (optional)
  - `metrics[]` (required)
- Builds `MetricResourceServiceDTO` with:
  - `serviceName` (required)
  - `replicas[]` (required)

### Docker Swarm Support
- Updated `DockerContainerAdapter` to extract service name from `com.docker.swarm.service.name` label
- Parses container `startedAt` timestamp from Docker inspect response
- Automatic detection of deployment mode (no configuration needed):
  - **Swarm services**: Multiple replicas grouped by service name
  - **Standalone containers**: Each container treated as single-replica service
  - **Mixed environments**: Both modes can coexist on the same node

### Testing
- Updated all existing tests for new replica structure
- Added tests for Swarm service detection and multi-replica grouping
- Added tests for standalone container handling
- All tests passing ✅

## Example Payloads

**Docker Swarm (3 nginx replicas across 2 nodes):**
```json
{
  "hosts": [
    {
      "machineId": "swarm-node-1",
      "services": [
        {
          "serviceName": "nginx",
          "replicas": [
            {"containerId": "nginx.1.abc123", "metrics": [...]},
            {"containerId": "nginx.2.def456", "metrics": [...]}
          ]
        }
      ]
    },
    {
      "machineId": "swarm-node-2",
      "services": [
        {
          "serviceName": "nginx",
          "replicas": [
            {"containerId": "nginx.3.ghi789", "metrics": [...]}
          ]
        }
      ]
    }
  ]
}
```

**Docker Standalone (3 different containers):**
```json
{
  "hosts": [
    {
      "machineId": "node-1",
      "services": [
        {
          "serviceName": "my-nginx",
          "replicas": [{"containerId": "abc123", "metrics": [...]}]
        },
        {
          "serviceName": "my-redis",
          "replicas": [{"containerId": "def456", "metrics": [...]}]
        }
      ]
    }
  ]
}
```

## Acceptance Criteria

- ✅ Agent payload for `storeResourceMetrics` matches updated OpenAPI schema
- ✅ Existing metric flush flow works for all scenarios (host+service, service-only, retry/failure)
- ✅ Tests pass for new DTO structure
- ✅ No regressions in metric collection scheduling and flush behavior
- ✅ **Bonus**: Full Docker Swarm support with automatic detection

## Related Issue

Closes #37

## Testing

```bash
./gradlew test
./gradlew build
```

All tests passing, build successful.